### PR TITLE
clang_{format,tidy}: Format header files, format and tidy C++ file extensions

### DIFF
--- a/util/clang_format.py
+++ b/util/clang_format.py
@@ -3,22 +3,25 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Wrapper around clang-format which enumerates the C files to be formatted
-# in-place. Passes through any additional arguments.
+# Wrapper around clang-format which enumerates the C/C++ source and header
+# files to be formatted in-place. Passes through any additional arguments.
 
 import os
 import sys
+from pathlib import Path
 
 
 def main():
     c_files = []
+    format_extensions = [".c", ".h", ".cc", ".hh"]
     for directory, _, files in os.walk("sw"):
         c_files.extend(
-            os.path.join(directory, file)
+            Path(directory) / Path(file)
             for file in files
-            if file.endswith(".c")
+            if (Path(file).suffix in format_extensions)
         )
 
+    print(c_files)
     cmd = "clang-format"
     cmd_args = [cmd, "-i", *sys.argv[1:], *c_files]
     os.execvp(cmd, cmd_args)

--- a/util/clang_tidy.py
+++ b/util/clang_tidy.py
@@ -4,21 +4,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Wrapper around clang-tidy which provides the default build directory and
-# enumerates the C files to be linted. Passes through any additional arguments.
+# enumerates the C/C++ files to be linted. Passes through any additional
+# arguments.
 
 import os
 import sys
+from pathlib import Path
 
 DEFAULT_BUILD_DIR = "build/sw"
 
 
 def main():
     c_files = []
+    tidy_extensions = [".c", ".cc"]
     for directory, _, files in os.walk("sw"):
         c_files.extend(
-            os.path.join(directory, file)
+            Path(directory) / Path(file)
             for file in files
-            if file.endswith(".c")
+            if (Path(file).suffix in tidy_extensions)
         )
 
     cmd = "clang-tidy"


### PR DESCRIPTION
Currently we do not have any but this will change soon, so better anticipate them.

AFAIK `clang-tidy` doesn't need header files specified as they do not appear in the compilation database as compilation objects (we do not do this in QEMU for instance).