### PR TITLE
[nix] Configure env variables to tell uv not to manage python

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,12 @@
               llvm_cheri
             ]);
           buildInputs = with pkgs; [libelf zlib];
+          env = {
+            # Prevent uv from managing Python downloads
+            UV_PYTHON_DOWNLOADS = "never";
+            # Force uv to use nixpkgs Python interpreter
+            UV_PYTHON = pythonSet.python.interpreter;
+          };
         };
         legacy = pkgs.mkShell {
           name = "mocha-legacy";


### PR DESCRIPTION
This fixes this error: https://github.com/lowRISC/mocha/actions/runs/20594967460/job/59149657971