### PR TITLE
[dv] Bash shell error fixed for DVSim on NixOS

### DIFF
--- a/hw/vendor/lowrisc_ip/dv/tools/dvsim/sim.mk
+++ b/hw/vendor/lowrisc_ip/dv/tools/dvsim/sim.mk
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-export SHELL  := /bin/bash
+export SHELL  := /usr/bin/env bash
 .DEFAULT_GOAL := all
 
 LOCK_ROOT_DIR ?= flock --timeout 3600 ${proj_root} --command

--- a/hw/vendor/patches/lowrisc_ip/dv_tools/0004-Bash-Fix.patch
+++ b/hw/vendor/patches/lowrisc_ip/dv_tools/0004-Bash-Fix.patch
@@ -1,0 +1,13 @@
+diff --git a/dvsim/sim.mk b/dvsim/sim.mk
+index bd03c81..8cf7e4b 100644
+--- a/dvsim/sim.mk
++++ b/dvsim/sim.mk
+@@ -2,7 +2,7 @@
+ # Licensed under the Apache License, Version 2.0, see LICENSE for details.
+ # SPDX-License-Identifier: Apache-2.0
+ 
+-export SHELL  := /bin/bash
++export SHELL  := /usr/bin/env bash
+ .DEFAULT_GOAL := all
+ 
+ LOCK_ROOT_DIR ?= flock --timeout 3600 ${proj_root} --command


### PR DESCRIPTION
Instead of using /bin/bash we should use the more portable: /usr/bin/env bash

This works on more systems and avoids an error specifically on NixOS.