### PR TITLE
ci: build verilator using more than one core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
 
       - name: Build verilator
         run: |
-          fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:mocha:top_chip_system
+          JOBS=$(($(nproc) / 4))
+          MAKEFLAGS="-j$JOBS" fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:mocha:top_chip_system
 
       - name: Run verilator software tests
         run: |


### PR DESCRIPTION
This reduces build time of the Verilator simulation in CI from 4 minutes to about 1 minute using a quarter of the cores on our self-hosted runner. With all cores there is only a marginal improvement down to about 50 seconds.