### PR TITLE
[dv] Add SPI Device block level DV from OpenTitan

### DIFF
--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -20,6 +20,8 @@
   use_cfgs: [
     // IPs.
     "{proj_root}/hw/vendor/lowrisc_ip/ip/uart/dv/uart_sim_cfg.hjson",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson", // As per mocha issue #271, keep both SPI cfgs until a decision is made
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
     // Top-level IPs.
     // Top level.
   ]

--- a/hw/vendor/lowrisc_ip.vendor.hjson
+++ b/hw/vendor/lowrisc_ip.vendor.hjson
@@ -29,7 +29,7 @@
     // Hardware IP blocks.
     {from: "hw/ip/lc_ctrl",    to: "ip/lc_ctrl"}, // Dependency of crossbar.
     {from: "hw/ip/rv_timer",   to: "ip/rv_timer"}, // Timer.
-    {from: "hw/ip/spi_device", to: "ip/spi_device"}, // SPI device.
+    {from: "hw/ip/spi_device", to: "ip/spi_device", patch_dir: "spi_device"}, // SPI device.
     {from: "hw/ip/tlul",       to: "ip/tlul", patch_dir: "tlul"}, // Memory bus.
     {from: "hw/ip/uart",       to: "ip/uart", patch_dir: "uart"}, // Serial input and output.
 

--- a/hw/vendor/lowrisc_ip/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_device/data/spi_device_testplan.hjson
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "spi_device"
-  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "spi_device_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson
@@ -18,24 +18,22 @@
   fusesoc_core: lowrisc:dv:spi_device_sim:0.1
 
   // Testplan hjson file.
-  testplan: "{proj_root}/hw/ip/spi_device/data/spi_device_testplan.hjson"
+  testplan: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/data/spi_device_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
-  ral_spec: "{proj_root}/hw/ip/spi_device/data/spi_device.hjson"
+  ral_spec: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/data/spi_device.hjson"
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"
-                // TODO, enable stress_all_with_rand_reset later
-                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson"
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 
   // Add additional tops for simulation.
@@ -50,18 +48,6 @@
   // Default UVM test and seq class name.
   uvm_test: spi_device_base_test
   uvm_test_seq: spi_device_base_vseq
-
-  // Need to override the default output directory
-  overrides: [
-    {
-      name: scratch_path
-      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
-    }
-    {
-      name: rel_path
-      value: "hw/ip/{name}_{variant}/dv"
-    }
-  ]
 
   // List of test specifications.
   tests: [

--- a/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson
@@ -6,13 +6,13 @@
   variant: 1r1w
 
   // Import the base spi_device sim_cfg file
-  import_cfgs: ["{proj_root}/hw/ip/spi_device/dv/base_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson"]
 
   build_opts: ["+define+SRAM_TYPE=spi_device_pkg::SramType1r1w"]
 
   // Add UART specific exclusion files.
   vcs_cov_excl_files: [
-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_cov_excl.el",
-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_1r1w_unr_cov_excl.el",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_cov_excl.el",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_1r1w_unr_cov_excl.el",
   ]
 }

--- a/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson
@@ -6,14 +6,14 @@
   variant: 2p
 
   // Import the base spi_device sim_cfg file
-  import_cfgs: ["{proj_root}/hw/ip/spi_device/dv/base_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson"]
 
   // Enable the appropriate build mode for all tests
   build_opts: ["+define+SRAM_TYPE=spi_device_pkg::SramType2p"]
 
   // Add UART specific exclusion files.
   vcs_cov_excl_files: [
-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_cov_excl.el",
-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_2p_unr_cov_excl.el",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_cov_excl.el",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_2p_unr_cov_excl.el",
   ]
 }

--- a/hw/vendor/patches/lowrisc_ip/spi_device/0001_Fix_Paths.patch
+++ b/hw/vendor/patches/lowrisc_ip/spi_device/0001_Fix_Paths.patch
@@ -1,0 +1,125 @@
+diff --git a/data/spi_device_testplan.hjson b/data/spi_device_testplan.hjson
+index 1092cc1..352fc89 100644
+--- a/data/spi_device_testplan.hjson
++++ b/data/spi_device_testplan.hjson
+@@ -3,12 +3,12 @@
+ // SPDX-License-Identifier: Apache-2.0
+ {
+   name: "spi_device"
+-  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
++  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/mem_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                      "spi_device_sec_cm_testplan.hjson"]
+   testpoints: [
+     {
+diff --git a/dv/base_sim_cfg.hjson b/dv/base_sim_cfg.hjson
+index ef9a7dd..d018345 100644
+--- a/dv/base_sim_cfg.hjson
++++ b/dv/base_sim_cfg.hjson
+@@ -18,24 +18,24 @@
+   fusesoc_core: lowrisc:dv:spi_device_sim:0.1
+ 
+   // Testplan hjson file.
+-  testplan: "{proj_root}/hw/ip/spi_device/data/spi_device_testplan.hjson"
++  testplan: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/data/spi_device_testplan.hjson"
+ 
+   // RAL spec - used to generate the RAL model.
+-  ral_spec: "{proj_root}/hw/ip/spi_device/data/spi_device.hjson"
++  ral_spec: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/data/spi_device.hjson"
+ 
+   // Import additional common sim cfg files.
+   import_cfgs: [// Project wide common sim cfg file
+-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
+                 // Common CIP test lists
+-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
+-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson"
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_all_test.hjson"
+                 // TODO, enable stress_all_with_rand_reset later
+-                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
++                // "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson"
+                 ]
+ 
+   // Add additional tops for simulation.
+@@ -51,18 +51,6 @@
+   uvm_test: spi_device_base_test
+   uvm_test_seq: spi_device_base_vseq
+ 
+-  // Need to override the default output directory
+-  overrides: [
+-    {
+-      name: scratch_path
+-      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
+-    }
+-    {
+-      name: rel_path
+-      value: "hw/ip/{name}_{variant}/dv"
+-    }
+-  ]
+-
+   // List of test specifications.
+   tests: [
+     {
+diff --git a/dv/spi_device_1r1w_sim_cfg.hjson b/dv/spi_device_1r1w_sim_cfg.hjson
+index f48986d..83c257b 100644
+--- a/dv/spi_device_1r1w_sim_cfg.hjson
++++ b/dv/spi_device_1r1w_sim_cfg.hjson
+@@ -6,13 +6,13 @@
+   variant: 1r1w
+ 
+   // Import the base spi_device sim_cfg file
+-  import_cfgs: ["{proj_root}/hw/ip/spi_device/dv/base_sim_cfg.hjson"]
++  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson"]
+ 
+   build_opts: ["+define+SRAM_TYPE=spi_device_pkg::SramType1r1w"]
+ 
+   // Add UART specific exclusion files.
+   vcs_cov_excl_files: [
+-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_cov_excl.el",
+-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_1r1w_unr_cov_excl.el",
++    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_cov_excl.el",
++    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_1r1w_unr_cov_excl.el",
+   ]
+ }
+diff --git a/dv/spi_device_2p_sim_cfg.hjson b/dv/spi_device_2p_sim_cfg.hjson
+index 23f0bc6..a7ba8c7 100644
+--- a/dv/spi_device_2p_sim_cfg.hjson
++++ b/dv/spi_device_2p_sim_cfg.hjson
+@@ -6,14 +6,14 @@
+   variant: 2p
+ 
+   // Import the base spi_device sim_cfg file
+-  import_cfgs: ["{proj_root}/hw/ip/spi_device/dv/base_sim_cfg.hjson"]
++  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson"]
+ 
+   // Enable the appropriate build mode for all tests
+   build_opts: ["+define+SRAM_TYPE=spi_device_pkg::SramType2p"]
+ 
+   // Add UART specific exclusion files.
+   vcs_cov_excl_files: [
+-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_cov_excl.el",
+-    "{proj_root}/hw/ip/spi_device/dv/cov/spi_device_2p_unr_cov_excl.el",
++    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_cov_excl.el",
++    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/cov/spi_device_2p_unr_cov_excl.el",
+   ]
+ }

--- a/hw/vendor/patches/lowrisc_ip/spi_device/0002_update_sim_cfg.patch
+++ b/hw/vendor/patches/lowrisc_ip/spi_device/0002_update_sim_cfg.patch
@@ -1,0 +1,15 @@
+diff --git a/dv/base_sim_cfg.hjson b/dv/base_sim_cfg.hjson
+index d018345..8bbf40c 100644
+--- a/dv/base_sim_cfg.hjson
++++ b/dv/base_sim_cfg.hjson
+@@ -33,9 +33,7 @@
+                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
+                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson"
+                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+-                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_all_test.hjson"
+-                // TODO, enable stress_all_with_rand_reset later
+-                // "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson"
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson"
+                 ]
+ 
+   // Add additional tops for simulation.


### PR DESCRIPTION
  - Path fixes

Run regression with:
`dvsim hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_{1r1w,2p}_sim_cfg.hjson -i smoke --tool xcelium`