### PR TITLE
[dv] fix the scratch dir config

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -5,9 +5,9 @@
   project: mocha
 
   // Default directory structure for the output
-  scratch_base_path: "{scratch_root}/{dut}.{flow}.{tool}"
-  scratch_path:      "{scratch_base_path}/{branch}"
-  tool_srcs_dir:     "{scratch_path}/{tool}"
+  scratch_base_path:  "{scratch_root}/{branch}"
+  scratch_path:       "{scratch_base_path}/{dut}.{flow}.{tool}"
+  tool_srcs_dir:      "{scratch_path}/{tool}"
 
   // Common DVSIM data structures
   build_pass_patterns: []

--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -5,7 +5,7 @@
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
   // cfgs of the IPs and the full chip used in top_chip. This enables the common
   // regression sets to be run in one shot.
-  name: top_chip_batch_sim
+  name: top_mocha_batch_sim
 
   import_cfgs: [
     // Project wide common cfg file


### PR DESCRIPTION
The scratch path and scratch base path were switched, meaning DVSim didn't understand where to generate the reports. This commit puts the branch back as a top level directory in the scratch dir.

If we want to support the inverted directory structure then DVSim needs updating to support this.

Before this change DVSim fails to generate reports, and the debugger shows the issue is the scratch base path:
```
(Pdb) self.scratch_base_path
'/home/jamesm/base/mocha/scratch/.sim.{tool}'
```

After this PR:
<img width="1042" height="470" alt="image" src="https://github.com/user-attachments/assets/04dc3e17-9cbe-4da1-8f1d-7d35ffc68ffd" />