### PR TITLE
[dv] Default simulator to Xcelium for uart and spi_device

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_device/dv/base_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:spi_device_sim:0.1

--- a/hw/vendor/lowrisc_ip/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/uart/dv/uart_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:uart_sim:0.1

--- a/hw/vendor/patches/lowrisc_ip/spi_device/0003_default_tool_sim_cfg.patch
+++ b/hw/vendor/patches/lowrisc_ip/spi_device/0003_default_tool_sim_cfg.patch
@@ -1,0 +1,13 @@
+diff --git a/dv/base_sim_cfg.hjson b/dv/base_sim_cfg.hjson
+index 8bbf40c..58e9c99 100644
+--- a/dv/base_sim_cfg.hjson
++++ b/dv/base_sim_cfg.hjson
+@@ -12,7 +12,7 @@
+   tb: tb
+
+   // Simulator used to sign off this block
+-  tool: vcs
++  tool: xcelium
+
+   // Fusesoc core file used for building the file list.
+   fusesoc_core: lowrisc:dv:spi_device_sim:0.1

--- a/hw/vendor/patches/lowrisc_ip/uart/0002_default_tool_sim_cfg.patch
+++ b/hw/vendor/patches/lowrisc_ip/uart/0002_default_tool_sim_cfg.patch
@@ -1,0 +1,13 @@
+diff --git a/dv/uart_sim_cfg.hjson b/dv/uart_sim_cfg.hjson
+index 812dc65..e05d17e 100644
+--- a/dv/uart_sim_cfg.hjson
++++ b/dv/uart_sim_cfg.hjson
+@@ -12,7 +12,7 @@
+   tb: tb
+
+   // Simulator used to sign off this block
+-  tool: vcs
++  tool: xcelium
+
+   // Fusesoc core file used for building the file list.
+   fusesoc_core: lowrisc:dv:uart_sim:0.1


### PR DESCRIPTION
Need to change the default simulator as it makes the dashboard regression failing.

> [!NOTE]
> We have tried to override the `tool` attribute from the `hw/top_chip/dv/mocha_sim_cfgs.hjson` file, but it doesn't work.