### PR TITLE
[cmake] Downgrade the minimum version

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 4.1)
+cmake_minimum_required(VERSION 3.22)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cheri_toolchain.cmake")


### PR DESCRIPTION
To align with the dv regressions container installed version