### PR TITLE
[ci] Disable SPI device 1r1w configuration

### DIFF
--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -20,7 +20,7 @@
   use_cfgs: [
     // IPs.
     "{proj_root}/hw/vendor/lowrisc_ip/ip/uart/dv/uart_sim_cfg.hjson",
-    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson", // As per mocha issue #271, keep both SPI cfgs until a decision is made
+    //"{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson", // As per mocha issue #271, keep this here as a reminder. Currently Mocha uses the two-port version so leave out the 1R1W for now.
     "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
     // Top-level IPs.
     // Top level.


### PR DESCRIPTION
This is because two port and one read one write are conflicting at the moment.