### PR TITLE
Fix regressions

### DIFF
--- a/hw/top_chip/dv/top_chip_sim_cfg.hjson
+++ b/hw/top_chip/dv/top_chip_sim_cfg.hjson
@@ -47,8 +47,8 @@
     {
       name: uart_smoke
       uvm_test_seq: top_chip_dv_uart_base_vseq
-      sw_images: ["uart_smoketest:5"]
-      run_opts: ["+ChipMemSRAM_image_file={run_dir}/uart_smoketest.vmem"]
+      sw_images: ["uart_smoketest_vanilla_bare:5"]
+      run_opts: ["+ChipMemSRAM_image_file={run_dir}/uart_smoketest_vanilla_bare.vmem"]
     }
   ]
 

--- a/sw/device/lib/test_framework/main.c
+++ b/sw/device/lib/test_framework/main.c
@@ -50,10 +50,16 @@ test_exception_handler(struct trap_registers *registers, struct trap_context *co
 
 void system_reset()
 {
+    extern char BOOT_ROM_OFFSET[];
     /* 
      * We don't have a hardware system reset yet. So we workaround by jumping back to the bootROM.
      */
     enum { bootROM = 0x10000080 };
+    bool is_dv = ((uintptr_t)BOOT_ROM_OFFSET == 0x0);
+    if (is_dv) {
+        return;
+    }
+
     typedef void (*reset_handler_t)(void);
     reset_handler_t reset = (reset_handler_t)bootROM;
 #if defined(__riscv_zcherihybrid)


### PR DESCRIPTION
Now binaries are different for fpga and simulation, so we need to give it the full name in the top_chip_sim_cfg.hjson.