### PR TITLE
[prim, alert, cov] Fixed the nightly failure

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -6,7 +6,7 @@
   name: prim_alert
 
   // Top level dut name (sv module).
-  dut: prim_alert
+  dut: prim_alert_tb
 
   // Top level testbench name (sv module).
   tb: prim_alert_tb
@@ -84,7 +84,7 @@
     }
     {
       name: xcelium_cov_cfg_file
-      value: ""
+      value: "{default_xcelium_cov_cfg_file}"
     }
   ]
 }


### PR DESCRIPTION
This PR consist of 2 fixes:

1) This was failing because of an empty argument provided
   for -covfile option that expects a .ccf file.

2) We provided dut name as "prim_alert" to -covdut
   argument which is not the actual name of the module.