### PR TITLE
Teach xcelium to grab cov when multiple DUTs are involved

### DIFF
--- a/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson
@@ -157,4 +157,7 @@
   // Build-specific coverage cfg files for Xcelium.
   default_xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover.ccf"
   cover_reg_top_xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover_reg_top.ccf"
+
+  cov_dut_args: "-covdut {dut}"
+  cov_top_args: ["{dut}"]
 }

--- a/hw/vendor/lowrisc_ip/dv/tools/dvsim/xcelium.hjson
+++ b/hw/vendor/lowrisc_ip/dv/tools/dvsim/xcelium.hjson
@@ -101,6 +101,8 @@
     // job prefix
     {job_prefix: "{job_prefix}"}
 
+    {COV_TOPS: "{cov_top_args}"}
+
   ]
 
   // Supported wave dumping formats (in order of preference).
@@ -229,7 +231,7 @@
       build_opts: [// Enable the required cov metrics.
                    "-coverage {cov_metrics}",
                    // Limit the scope of coverage collection to the DUT.
-                   "-covdut {dut}",
+                   "{cov_dut_args}",
                    // Set the coverage configuration file
                    "-covfile {xcelium_cov_cfg_file}",
                    // Don't warn about the switches we set that will be default in future releases.

--- a/hw/vendor/lowrisc_ip/dv/tools/xcelium/cov_report.tcl
+++ b/hw/vendor/lowrisc_ip/dv/tools/xcelium/cov_report.tcl
@@ -21,40 +21,44 @@ set cov_report_dir [string trim $::env(cov_report_dir) " \"'"]
 set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
 
 # Set the DUT name.
-set dut [string trim $::env(DUT_TOP)]
-set dut_uc [string toupper $dut]
+set dut [string trim $::env(COV_TOPS)]
 
 # Generate the text report (summary is sufficient).
-report -summary \
-  -inst uvm_pkg $dut \
-  -metrics all \
-  -all \
-  -cumulative on \
-  -local off \
-  -grading covered \
-  -out $cov_report_dir/cov_report.txt
+set x []
+foreach x $dut {
+  report -summary \
+    -inst uvm_pkg $x \
+    -metrics all \
+    -all \
+    -cumulative on \
+    -local off \
+    -grading covered \
+    -out $cov_report_dir/${x}_cov_report.txt
 
-# Generate the functional coverage report for tracking.
-report -summary \
-  -type \
-  -all \
-  -metrics covergroup \
-  -source off \
-  -out $cov_report_dir/cov_report_cg.txt
+  # Generate the functional coverage report for tracking.
+  report -summary \
+    -type \
+    -all \
+    -metrics covergroup \
+    -source off \
+    -out $cov_report_dir/cov_report_cg.txt
 
-# Generate the HTML reports.
-report_metrics \
-  -out $cov_report_dir \
-  -overwrite \
-  -title $dut_uc \
-  -detail \
-  -metrics all \
-  -kind aggregate \
-  -source on \
-  -exclComments \
-  -assertionStatus \
-  -allAssertionCounters \
-  -all
+  set dut_uc [string toupper $x]
+
+  # Generate the HTML reports.
+  report_metrics \
+    -out $cov_report_dir \
+    -overwrite \
+    -title $dut_uc \
+    -detail \
+    -metrics all \
+    -kind aggregate \
+    -source on \
+    -exclComments \
+    -assertionStatus \
+    -allAssertionCounters \
+    -all
+}
 
 # rank the test runs
 rank -runfile $cov_merge_db_dir/runs.txt -html -out $cov_report_dir/grading

--- a/hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -6,7 +6,7 @@
   name: prim_alert
 
   // Top level dut name (sv module).
-  dut: prim_alert_tb
+  dut: prim_alert
 
   // Top level testbench name (sv module).
   tb: prim_alert_tb
@@ -85,6 +85,14 @@
     {
       name: xcelium_cov_cfg_file
       value: "{default_xcelium_cov_cfg_file}"
+    }
+    {
+      name: cov_dut_args
+      value: "-covdut prim_alert_sender -covdut prim_alert_receiver"
+    }
+    {
+      name: cov_top_args
+      value: ["prim_alert_sender", "prim_alert_receiver"]
     }
   ]
 }


### PR DESCRIPTION
This work is in progress. With the commit in this PR, it will let you generate `cov_report.txt` file. The commit is tested against `prim_alert*` config. The `cov_report.txt` generated as a result of command `dvsim hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson -i prim_sync_alert -t xcelium --cov -fs` looks like only `toggle_coverage` is collected. This requires to further look into `.ccfs`

**prim_alert_sender_cov_report.txt**
```
Legend: Metric* means cumulative e.g. Block* means Cumulative Block Coverage
name                                     Block* Covered       Expression* Covered  Toggle* Covered      Statement* Covered   Fsm* Covered         Assertion* Covered   CoverGroup* Covered  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
prim_alert_sender                        n/a                  n/a                  100.00% (12/12)      n/a                  n/a                  n/a                  n/a                  
```