### PR TITLE
[ci] Include output of failed ctests in CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
   verilator-test:
     runs-on: ["self-hosted", "nixos", "X64"]
-    needs: lint-check 
+    needs: lint-check
 
     defaults:
       run:
@@ -79,11 +79,11 @@ jobs:
 
       - name: Run verilator software tests
         run: |
-          ctest --test-dir build/sw -R sim_verilator
+          ctest --test-dir build/sw -R sim_verilator --output-on-failure
 
   fpga-build:
     runs-on: ["ubuntu-22.04-bitstream"]
-    needs: verilator-test 
+    needs: verilator-test
     outputs:
       bitstream-hash: ${{ steps.hash-bitstream.outputs.hash }}
     steps:
@@ -122,7 +122,7 @@ jobs:
 
   fpga-test:
     runs-on: ["self-hosted", "ubuntu-22.04-fpga", "genesys2"]
-    needs: fpga-build 
+    needs: fpga-build
     steps:
       - uses: actions/checkout@v5
 
@@ -158,4 +158,4 @@ jobs:
       - name: Run FPGA tests
         shell: "nix develop -c bash -e {0}"
         run: |
-          ctest --test-dir build/sw -R fpga
+          ctest --test-dir build/sw -R fpga --output-on-failure


### PR DESCRIPTION
Make it easier to figure out what has gone wrong in the ctest tests in CI.
Particularly the FPGA ones that are harder to reproduce locally.