### PR TITLE
[fpga] Remove CDC timing exceptions

### DIFF
--- a/hw/top_chip/data/timing_genesys2.xdc
+++ b/hw/top_chip/data/timing_genesys2.xdc
@@ -9,10 +9,12 @@ create_clock -period 5.000 -waveform {0 2.5} -name sys_clk_pin -add [get_ports s
 create_clock -period 10.000 -waveform {0 5} -name cfg_clk_pin -add [get_pins clk_gen/STARTUPE2_inst/CFGMCLK];
 
 ## Tag Controller to MIG AXI CDC Constraints
+## Removed since the custom attribute async cannot be used to select pins,
+## and the CDC paths can be timed without difficulty
 ## min(T_src, T_dst) = min(20ns, 5ns) = 5ns
-set_max_delay 5 \
-    -through [get_pins -hierarchical -filter async] \
-    -through [get_pins -hierarchical -filter async]
-set_false_path -hold \
-    -through [get_pins -hierarchical -filter async] \
-    -through [get_pins -hierarchical -filter async]
+## set_max_delay 5 \
+##     -through [get_pins -hierarchical -filter async] \
+##     -through [get_pins -hierarchical -filter async]
+## set_false_path -hold \
+##     -through [get_pins -hierarchical -filter async] \
+##     -through [get_pins -hierarchical -filter async]


### PR DESCRIPTION
Removed constraints to relax CDC timing for axi_cdc in genesys 2 top, since the custom attribute async cannot select any path, and there is no difficulty meeting timing without these constraints.

Without these constraints, hold time will be checked and setup time requirement of 5ns will be imposed accounting for source to destination clock skew. This will be no less reliable than adding constraints to relax timing.

Closes #364 