### PR TITLE
[sw] Slow down boot ROM LEDs

### DIFF
--- a/sw/device/bootrom/bootrom.c
+++ b/sw/device/bootrom/bootrom.c
@@ -61,7 +61,7 @@ bool spi_boot_strap(uart_t console)
 
     while (true) {
         // TODO: Use timer
-        if (count++ >= 1000) {
+        if (count++ >= 10000) {
             led_animation_run(gpio);
             count = 0;
         }


### PR DESCRIPTION
You can see the LEDs flicker but it would be nice if they were slower by default.