### PR TITLE
DRAM loading in Verilator

### DIFF
--- a/hw/top_chip/dv/verilator/top_chip_verilator.cc
+++ b/hw/top_chip/dv/verilator/top_chip_verilator.cc
@@ -12,7 +12,8 @@
 
 class MochaSim {
  public:
-  MochaSim(const char *ram_hier_path, int ram_size_words);
+  MochaSim(const char *sram_hier_path, int sram_size_words,
+           const char *dram_hier_path, int dram_size_words);
   virtual ~MochaSim() {}
   virtual int Main(int argc, char **argv);
 
@@ -20,15 +21,17 @@ class MochaSim {
  protected:
   top_chip_verilator _top;
   VerilatorMemUtil _memutil;
-  MemArea _ram;
+  MemArea _sram, _dram;
 
   virtual int Setup(int argc, char **argv, bool &exit_app);
   virtual void Run();
   virtual bool Finish();
 };
 
-MochaSim::MochaSim(const char *ram_hier_path, int ram_size_words)
-    : _ram(ram_hier_path, ram_size_words, 8) {}
+MochaSim::MochaSim(const char *sram_hier_path, int sram_size_words,
+                   const char *dram_hier_path, int dram_size_words)
+    : _sram(sram_hier_path, sram_size_words, 8),
+      _dram(dram_hier_path, dram_size_words, 8) {}
 
 int MochaSim::Main(int argc, char **argv) {
   bool exit_app;
@@ -53,7 +56,8 @@ int MochaSim::Setup(int argc, char **argv, bool &exit_app) {
   simctrl.SetTop(&_top, &_top.clk_i, &_top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  _memutil.RegisterMemoryArea("ram", 0x10000000, &_ram);
+  _memutil.RegisterMemoryArea("sram", 0x10000000, &_sram);
+  _memutil.RegisterMemoryArea("dram", 0x80000000, &_dram);
   simctrl.RegisterExtension(&_memutil);
 
   exit_app = false;
@@ -85,7 +89,9 @@ bool MochaSim::Finish() {
 int main(int argc, char **argv) {
   MochaSim mocha_sim(
       "TOP.top_chip_verilator.u_top_chip_system.u_axi_sram.u_ram",
-      16 * 1024 // 16k 64-bit words = 128 KiB
+      16 * 1024, // 16k 64-bit words = 128 KiB
+      "TOP.top_chip_verilator.u_dram_wrapper.u_ext_mem",
+      2 * 1024 * 1024 // = 2 GiB
   );
 
   return mocha_sim.Main(argc, argv);

--- a/sw/cheri_toolchain.cmake
+++ b/sw/cheri_toolchain.cmake
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-set(CHERI_FLAGS -march=rv64imc_zcherihybrid -mabi=l64pc128)
-set(VANILLA_FLAGS -march=rv64imc -mabi=lp64 -mcmodel=medlow)
+set(CHERI_FLAGS -march=rv64imc_zcherihybrid -mabi=l64pc128 -mcmodel=medany)
+set(VANILLA_FLAGS -march=rv64imc -mabi=lp64 -mcmodel=medany)
 
 set(CMAKE_SYSTEM_NAME Generic)
 

--- a/sw/cmake/tests.cmake
+++ b/sw/cmake/tests.cmake
@@ -35,7 +35,7 @@ endmacro()
 macro(mocha_add_verilator_test NAME)
     add_test(
         NAME ${NAME}_sim_verilator
-        COMMAND ${PROJECT_SOURCE_DIR}/../util/verilator_runner.sh ${NAME}
+        COMMAND ${PROJECT_SOURCE_DIR}/../util/verilator_runner.sh -E ${NAME}
     )
 endmacro()
 
@@ -121,4 +121,3 @@ macro(mocha_add_library)
 
     endforeach() # ARCH
 endmacro()
-

--- a/sw/device/lib/boot/boot.S
+++ b/sw/device/lib/boot/boot.S
@@ -187,7 +187,7 @@ zero_bss_end:
     /* derive a stack pointer from the infinite capability */
     /* limit stack size */
     llc csp, _stack_bottom
-    llc ct0, _stack_len
+    lgc ct0, _stack_len
     scaddr csp, ca0, sp
     scbnds csp, csp, t0
     /* stack grows downwards, so adjust address to top */
@@ -225,7 +225,7 @@ setup_scratchpad:
 
     /* set up a known-good stack capability in the scratchpad area */
     llc ct0, _stack_bottom
-    llc ct1, _stack_len
+    lgc ct1, _stack_len
     scaddr ct0, ca0, t0
     scbnds ct0, ct0, t1
     add ct0, ct0, t1

--- a/sw/device/lib/boot/dram_test.ld
+++ b/sw/device/lib/boot/dram_test.ld
@@ -1,0 +1,90 @@
+/* Copyright lowRISC contributors (COSMIC project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH(riscv)
+
+INCLUDE memory.ld
+
+MEMORY {
+    ram (RWX) : ORIGIN = ORIGIN(DRAM), LENGTH = LENGTH(DRAM)
+}
+
+/* Provided in init_vectors.S, immediately jumps into _start. */
+ENTRY(_init_vector)
+
+SECTIONS {
+    _program_start = ORIGIN(ram);
+
+    .init_vectors ORIGIN(ram) : {
+        *(.init_vectors)
+    } > ram
+
+    .text : {
+        . = ALIGN(8);
+        *(.text)
+        *(.text.*)
+        . = ALIGN(8);
+    } > ram
+
+    .rodata : {
+        . = ALIGN(8);
+        /* Small rodata before large rodata */
+        *(.srodata)
+        *(.srodata.*)
+        *(.rodata)
+        *(.rodata.*)
+        . = ALIGN(8);
+    } > ram
+
+    /* capability relocation entries */
+    /* __start___cap_relocs and __stop___cap_relocs are provided by the toolchain */
+    __cap_relocs : {
+        *(__cap_relocs)
+        . = ALIGN(8);
+    } > ram
+
+    .data : {
+        . = ALIGN(8);
+        /* Small data before large data */
+        *(.sdata)
+        *(.sdata.*)
+        *(.data)
+        *(.data.*)
+        . = ALIGN(8);
+    } > ram
+
+    .bss : {
+        . = ALIGN(8);
+        _bss_start = .;
+        _sbss = .; /* Rust */
+        /* Small bss before large bss */
+        *(.sbss)
+        *(.sbss.*)
+        *(.bss)
+        *(.bss.*)
+        *(COMMON)
+        . = ALIGN(8);
+        _ebss = .; /* Rust */
+        _bss_end = .;
+    } > ram
+
+    .got : {
+        . = ALIGN(8);
+        *(.got)
+        *(.got.*)
+        . = ALIGN(8);
+    } > ram
+
+    . = ALIGN(1024);
+    .stack : {
+        . = ALIGN(1024);
+        _stack_bottom = .;
+        . = . + 1024;
+        _stack_top = .;
+        _stack_len = _stack_top - _stack_bottom;
+    } > ram
+
+    . = ALIGN(8);
+    _program_end = .;
+}

--- a/sw/device/tests/CMakeLists.txt
+++ b/sw/device/tests/CMakeLists.txt
@@ -18,3 +18,5 @@ mocha_add_test(NAME tag_controller_tag_test SOURCES tag_controller/tag_test.c LI
 mocha_add_test(NAME timer_smoketest SOURCES timer/smoketest.c LIBRARIES ${LIBS} FPGA)
 mocha_add_test(NAME timer_interrupt_test SOURCES timer/interrupt.c LIBRARIES ${LIBS})
 mocha_add_test(NAME uart_smoketest SOURCES uart/smoketest.c LIBRARIES ${LIBS})
+
+add_subdirectory(dram)

--- a/sw/device/tests/dram/CMakeLists.txt
+++ b/sw/device/tests/dram/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This DRAM test is to test loading a binary into DRAM in Verilator,
+# before we have general support for running tests from DRAM.
+# For this test, we build a version of the test framework test linked at DRAM
+# which we load alongside the test binary. The test binary just jumps into DRAM.
+
+# TODO: This should be generalised to all tests once we have the ability to load
+# DRAM in all environments (FPGA, DV).
+
+set(LIBS hal runtime startup test_framework)
+
+add_executable(test_framework_test_vanilla_dram ../test_framework/smoketest.c)
+target_compile_options(test_framework_test_vanilla_dram PUBLIC ${VANILLA_FLAGS})
+foreach(LIB ${LIBS})
+    target_link_libraries(test_framework_test_vanilla_dram PUBLIC ${LIB}_vanilla)
+    target_include_directories(test_framework_test_vanilla_dram PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../../lib")
+endforeach()
+target_link_options(
+    test_framework_test_vanilla_dram PUBLIC
+    # Workaround: This address doesn't matter as we don't use system reset here,
+    # but it needs to be addressible by the medany code model.
+    "-Wl,--defsym,BOOT_ROM_OFFSET=0x80000000"
+    "-T" "dram_test.ld"
+    "-L" ${LDS_DIR}
+)
+
+add_executable(dram_test_rom ../dram/dram_test_rom.c)
+target_compile_options(dram_test_rom PUBLIC ${VANILLA_FLAGS})
+foreach(LIB ${LIBS})
+    target_link_libraries(dram_test_rom PUBLIC ${LIB}_vanilla)
+    target_include_directories(dram_test_rom PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../../lib")
+endforeach()
+target_link_options(
+    dram_test_rom PUBLIC
+    "-Wl,--defsym,BOOT_ROM_OFFSET=0x00"
+    "-T" "${LDS}"
+    "-L" ${LDS_DIR}
+)
+
+add_test(
+    NAME dram_load_test_sim_verilator
+    COMMAND ${PROJECT_SOURCE_DIR}/../util/verilator_runner.sh -E dram_test_rom -E test_framework_test_vanilla_dram
+)

--- a/sw/device/tests/dram/dram_test_rom.c
+++ b/sw/device/tests/dram/dram_test_rom.c
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (COSMIC project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hal/mocha.h"
+#include "hal/uart.h"
+#include "runtime/print.h"
+#if defined(__riscv_zcherihybrid)
+#include <cheriintrin.h>
+#endif /* defined(__riscv_zcherihybrid) */
+
+// This test expects a test binary to be loaded into DRAM.
+// This will just jump to the start of that test.
+
+bool test_main(void)
+{
+    uart_t console = mocha_system_uart();
+    uart_init(console);
+
+    enum : uint64_t { boot_vector = dram_base + 0x80 };
+    uprintf(console, "jumping to DRAM boot vector: %lx\n", boot_vector);
+
+    void (*boot)(void) = (void (*)(void))boot_vector;
+    boot();
+
+    /* Test in DRAM should have succeeded and terminated the test */
+    return false;
+}

--- a/util/verilator_runner.sh
+++ b/util/verilator_runner.sh
@@ -6,4 +6,4 @@
 ROOT_DIR=$(dirname "$0")/..
 
 timeout 5m $ROOT_DIR/build/lowrisc_mocha_top_chip_verilator_0/sim-verilator/Vtop_chip_verilator \
-  -E $1 > /dev/null 2>&1
+  $@ > /dev/null 2>&1


### PR DESCRIPTION
Adds the DRAM as a memory area that can be loaded on the command line, so that we can skip the bootloader in Verilator in the future.

The memory can be loaded into using multiple `-E` flags to load binaries into the corresponding memory areas, ~~or using the `-r` and `-m` flags to explicitly load into ROM/SRAM or DRAM.~~

~~We currently don't use this functionality as we still need a Verilator bypass in the boot ROM before we can run all tests from DRAM on all environments.~~

Added a test now, needed quite a bit of machinery to get it going (needed the ability to load multiple ELF's with the test runner, compile and link for DRAM which we do not do yet) but that should be cleaned up once we can load all our tests into DRAM in addition to just SRAM.

Closes https://github.com/lowRISC/mocha/issues/377.