### PR TITLE
[fusesoc] Edalize flow used

### DIFF
--- a/hw/top_chip/chip_mocha_genesys2.core
+++ b/hw/top_chip/chip_mocha_genesys2.core
@@ -48,12 +48,12 @@ targets:
 
   synth:
     <<: *default_target
-    default_tool: vivado
+    flow: synth
+    flow_options:
+      tool: vivado
+      part: "xc7k325tffg900-2" # Genesys 2 with K325T
     filesets_append:
       - files_constraints
     toplevel: chip_mocha_genesys2
     parameters:
       - BootRomInitFile
-    tools:
-      vivado:
-        part: "xc7k325tffg900-2" # Genesys 2 with K325T

--- a/hw/top_chip/dv/top_chip_sim.core
+++ b/hw/top_chip/dv/top_chip_sim.core
@@ -46,7 +46,9 @@ targets:
     toplevel: tb
     # This is required as DVSim always expects a scr file, but in practice we are only running
     # fusesoc up to the point it generates the filelist file.
-    default_tool: vcs
+    flow: sim
+    flow_options:
+      tool: vcs
 
 parameters:
   INST_SIM_SRAM:

--- a/hw/top_chip/dv/verilator/top_chip_verilator.core
+++ b/hw/top_chip/dv/verilator/top_chip_verilator.core
@@ -43,38 +43,28 @@ targets:
     <<: *default_target
     parameters:
       - INST_SIM_SRAM=true
-    default_tool: verilator
+    flow: sim
+    flow_options:
+      tool: verilator
+      mode: cc
+      verilator_options:
+        # Disabling tracing reduces compile times but doesn't have a
+        # huge influence on runtime performance.
+        - '--trace'
+        - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+        - '--trace-structs'
+        - '--trace-params'
+        - '--trace-max-array 1024'
+        - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_chip_verilator"'
+        - '-LDFLAGS "-pthread -lutil -lelf"'
+        - '--assert'
+        - '-Wall'
+        # RAM primitives wider than 64bit (required for ECC) fail to build in
+        # Verilator without increasing the unroll count (see Verilator#1266)
+        - "--unroll-count 72"
     filesets_append:
       - files_verilator
     toplevel: top_chip_verilator
-    tools:
-      verilator:
-        mode: cc
-        verilator_options:
-          # Disabling tracing reduces compile times but doesn't have a
-          # huge influence on runtime performance.
-          - '--trace'
-          - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
-          - '--trace-structs'
-          - '--trace-params'
-          - '--trace-max-array 1024'
-          - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_chip_verilator"'
-          - '-LDFLAGS "-pthread -lutil -lelf"'
-          - '--assert'
-          - '-Wall'
-          # RAM primitives wider than 64bit (required for ECC) fail to build in
-          # Verilator without increasing the unroll count (see Verilator#1266)
-          - "--unroll-count 72"
-
-  lint:
-    <<: *default_target
-    default_tool: verilator
-    filesets_append:
-      - files_verilator
-    toplevel: top_chip_verilator
-    tools:
-      verilator:
-        mode: lint-only
 
 parameters:
   INST_SIM_SRAM:

--- a/hw/top_chip/top_chip_system.core
+++ b/hw/top_chip/top_chip_system.core
@@ -45,34 +45,36 @@ targets:
     toplevel: top_chip_system
 
   sim:
-    default_tool: verilator
+    flow: sim
+    flow_options:
+      tool: verilator
     filesets:
       - files_rtl
     toplevel: top_chip_system
 
   lint:
     <<: *default_target
-    default_tool: verilator
+    flow: lint
+    flow_options:
+      tool: verilator
+      mode: lint-only
+      verilator_options:
+        # Disabling tracing reduces compile times but doesn't have a
+        # huge influence on runtime performance.
+        - '--trace'
+        - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+        - '--trace-structs'
+        - '--trace-params'
+        - '--trace-max-array 1024'
+        - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_chip_verilator"'
+        - '-LDFLAGS "-pthread -lutil -lelf"'
+        - '--assert'
+        - '-Wall'
+        # RAM primitives wider than 64bit (required for ECC) fail to build in
+        # Verilator without increasing the unroll count (see Verilator#1266)
+        - "--unroll-count 72"
     parameters:
       - SYNTHESIS=true
-    tools:
-      verilator:
-        mode: lint-only
-        verilator_options:
-          # Disabling tracing reduces compile times but doesn't have a
-          # huge influence on runtime performance.
-          - '--trace'
-          - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
-          - '--trace-structs'
-          - '--trace-params'
-          - '--trace-max-array 1024'
-          - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_chip_verilator"'
-          - '-LDFLAGS "-pthread -lutil -lelf"'
-          - '--assert'
-          - '-Wall'
-          # RAM primitives wider than 64bit (required for ECC) fail to build in
-          # Verilator without increasing the unroll count (see Verilator#1266)
-          - "--unroll-count 72"
 
 parameters:
   SYNTHESIS:


### PR DESCRIPTION
Following the guidance here:
https://edalize.readthedocs.io/en/latest/ref/migrations.html#migrating-from-the-tool-api-to-the-flow-api

Also remove lint target for Verilator lint as it is broken.