### PR TITLE
[dv] Mailbox smoke CHERI enabled

### DIFF
--- a/hw/top_chip/dv/top_chip_sim_cfg.hjson
+++ b/hw/top_chip/dv/top_chip_sim_cfg.hjson
@@ -197,8 +197,7 @@
         "spi_device_smoke_cheri",
         "gpio_smoke",
         "mailbox_smoke",
-        //TODO currently broken.
-        // "mailbox_smoke_cheri"
+        "mailbox_smoke_cheri",
       ]
     }
     {


### PR DESCRIPTION
This TODO was left over from a time when the mailbox smoke test still used the reset manager. Now that that is not the case we can have both the vanilla and cheri version run for this test.