### PR TITLE
[i2c,dv] Fix sim_cfg.hjson path in mocha_sim_cfgs

### DIFF
--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -26,7 +26,7 @@
     "{proj_root}/hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
-    "{proj_root}/hw/top_chip/ip/i2c/dv/i2c_sim_cfg.hjson",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/i2c/dv/i2c_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/tmp_sim_cfg/gpio_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/tmp_sim_cfg/rom_ctrl_32kB_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/tmp_sim_cfg/rv_dm_use_jtag_interface_sim_cfg.hjson",


### PR DESCRIPTION
While I tried to run this command:
`dvsim hw/top_chip/dv/mocha_sim_cfgs.hjson --select-cfgs gpio -i smoke --cov`

I had this log:
```
[C 260408 16:47:27 hjson:29] Failed to parse "/scratch/mvelay/mocha/hw/top_chip/ip/i2c/dv/i2c_sim_cfg.hjson" possibly due to bad path or syntax error.
[Errno 2] No such file or directory: '/scratch/mvelay/mocha/hw/top_chip/ip/i2c/dv/i2c_sim_cfg.hjson'
```

This PR follows https://github.com/lowRISC/mocha/pull/388.