### PR TITLE
 [chip, gpio, sw] Adding Verilator as an option to .cmake

### DIFF
--- a/sw/cmake/tests.cmake
+++ b/sw/cmake/tests.cmake
@@ -59,7 +59,7 @@ set(ARCHS_FLAGS           VANILLA_FLAGS       CHERI_FLAGS ) # Flags
 # the output executable name and all of the libraries it is linked against.
 macro(mocha_add_test)
     # parse arguments
-    set(options FPGA)
+    set(options FPGA SKIP_VERILATOR)
     set(one_value_args NAME)
     set(multi_value_args SOURCES LIBRARIES)
     cmake_parse_arguments(arg "${options}"
@@ -83,7 +83,7 @@ macro(mocha_add_test)
         # create artefacts
         mocha_add_executable_artefacts(${NAME})
 
-        if(SIM)
+        if(SIM AND NOT arg_SKIP_VERILATOR)
           mocha_add_verilator_test(${NAME})
         endif()
 


### PR DESCRIPTION
Merge [406](https://github.com/lowRISC/mocha/pull/406) first as a dependency

The motivation of this PR comes from [382](https://github.com/lowRISC/mocha/pull/382) which is adding a chip level GPIO smoke test. That test fails on verilator. Reason being different tops used for different platforms ( DVSim(Xcelium), Verilator, FPGA). For Xcelium, an interface is connecting the UVM to the GPIO. UVM has the control to drive GPIOs inputs. In [382](https://github.com/lowRISC/mocha/pull/382), SW waits for a specific pattern driven by UVM to arrive in data_in reg. If we run the exact test with the verilator top, which is using GPIO DPI, then the abilty to drive inputs depends on a host SW infrastructure which is currently missing.

Second problem is that we use cmake to build software images for DVSim, verilator and FPGA. We run tests on FPGA and Verilator in CI. If the build system develops an Xcelium compatible image and feed that image to Verilator and FPGA
to execute the test in CI then the test will fail due to the reason given in the first paragraph.

Hence, the best way forward is to make images only for the compatible paltforms.