### PR TITLE
[util] Main branch by default

### DIFF
--- a/hw/ip/common_cells/rtl/rr_arb_tree.sv
+++ b/hw/ip/common_cells/rtl/rr_arb_tree.sv
@@ -127,8 +127,8 @@ module rr_arb_tree #(
     /* verilator lint_off SPLITVAR */  // disable warning that is issued if bitwidth is 1
     idx_t    [2**NumLevels-2:0] index_nodes /* verilator split_var */; // propagates indices
     DataType [2**NumLevels-2:0] data_nodes  /* verilator split_var */; // propagates data
-    logic    [2**NumLevels-2:0] gnt_nodes   /* verilator split_var */; // propagates gnt to masters
-    logic    [2**NumLevels-2:0] req_nodes   /* verilator split_var */; // propagates reqs to slave
+    logic    [2**NumLevels-2:0] gnt_nodes   /* verilator split_var */; // propagates gnt to managers
+    logic    [2**NumLevels-2:0] req_nodes   /* verilator split_var */; // propagates reqs to subordinates
     /* verilator lint_on SPLITVAR */
 
     /* lint_off */

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -538,7 +538,7 @@ def ignore_patterns(base_dir, *patterns):
     return _ignore_patterns
 
 
-def clone_git_repo(repo_url, clone_dir, rev='master'):
+def clone_git_repo(repo_url, clone_dir, rev='main'):
     log.info('Cloning upstream repository %s @ %s', repo_url, rev)
 
     # Clone the whole repository


### PR DESCRIPTION
In Mocha we use main branch as default, so make the appropriate change in the vendor script.