### PR TITLE
spi_host dv ported from OpenTitan

### DIFF
--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -22,6 +22,7 @@
     "{proj_root}/hw/vendor/lowrisc_ip/ip/uart/dv/uart_sim_cfg.hjson",
     //"{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson", // As per mocha issue #271, keep this here as a reminder. Currently Mocha uses the two-port version so leave out the 1R1W for now.
     "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/dv/spi_host_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",

--- a/hw/vendor/lowrisc_ip.vendor.hjson
+++ b/hw/vendor/lowrisc_ip.vendor.hjson
@@ -35,7 +35,7 @@
     {from: "hw/ip/rv_core_ibex", to: "ip/rv_core_pkg", patch_dir: "rv_core_pkg"}, // RISC-V core package.
     {from: "hw/ip/rv_timer",     to: "ip/rv_timer", patch_dir: "rv_timer"}, // Timer.
     {from: "hw/ip/spi_device",   to: "ip/spi_device", patch_dir: "spi_device"}, // SPI device.
-    {from: "hw/ip/spi_host",     to: "ip/spi_host"}, // SPI host.
+    {from: "hw/ip/spi_host",     to: "ip/spi_host", patch_dir: "spi_host"}, // SPI host.
     {from: "hw/ip/tlul",         to: "ip/tlul", patch_dir: "tlul"}, // Memory bus.
     {from: "hw/ip/uart",         to: "ip/uart", patch_dir: "uart"}, // Serial input and output.
 

--- a/hw/vendor/lowrisc_ip/ip/spi_host/data/spi_host_testplan.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_host/data/spi_host_testplan.hjson
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "spi_host"
-  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "spi_host_sec_cm_testplan.hjson"],
   testpoints: [
     {

--- a/hw/vendor/lowrisc_ip/ip/spi_host/dv/spi_host_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/spi_host/dv/spi_host_sim_cfg.hjson
@@ -18,29 +18,29 @@
   fusesoc_core: lowrisc:dv:spi_host_sim:1.0
 
   // Testplan hjson file.
-  testplan: "{proj_root}/hw/ip/spi_host/data/spi_host_testplan.hjson"
+  testplan: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/data/spi_host_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
-  ral_spec: "{proj_root}/hw/ip/spi_host/data/spi_host.hjson"
+  ral_spec: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/data/spi_host.hjson"
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson", // TODO(#18886): enable for V3
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                //"{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson", // TODO(#18886): enable for V3
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["spi_host_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Coverage exclusion
-  xcelium_cov_refine_files: ["{proj_root}/hw/ip/spi_host/dv/cov/spi_host_unr_excl.vRefine"]
+  xcelium_cov_refine_files: ["{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/dv/cov/spi_host_unr_excl.vRefine"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/vendor/patches/lowrisc_ip/spi_host/0001_Sim_Path_Fixes.patch
+++ b/hw/vendor/patches/lowrisc_ip/spi_host/0001_Sim_Path_Fixes.patch
@@ -1,0 +1,69 @@
+diff --git a/data/spi_host_testplan.hjson b/data/spi_host_testplan.hjson
+index 70d3420..d5f35e2 100644
+--- a/data/spi_host_testplan.hjson
++++ b/data/spi_host_testplan.hjson
+@@ -3,12 +3,12 @@
+ // SPDX-License-Identifier: Apache-2.0
+ {
+   name: "spi_host"
+-  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
++  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/mem_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                      "spi_host_sec_cm_testplan.hjson"],
+   testpoints: [
+     {
+diff --git a/dv/spi_host_sim_cfg.hjson b/dv/spi_host_sim_cfg.hjson
+index c27bc3f..d8df8d1 100644
+--- a/dv/spi_host_sim_cfg.hjson
++++ b/dv/spi_host_sim_cfg.hjson
+@@ -18,29 +18,29 @@
+   fusesoc_core: lowrisc:dv:spi_host_sim:1.0
+
+   // Testplan hjson file.
+-  testplan: "{proj_root}/hw/ip/spi_host/data/spi_host_testplan.hjson"
++  testplan: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/data/spi_host_testplan.hjson"
+
+   // RAL spec - used to generate the RAL model.
+-  ral_spec: "{proj_root}/hw/ip/spi_host/data/spi_host.hjson"
++  ral_spec: "{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/data/spi_host.hjson"
+
+   // Import additional common sim cfg files.
+   import_cfgs: [// Project wide common sim cfg file
+-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
+                 // Common CIP test lists
+-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+-                //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson", // TODO(#18886): enable for V3
+-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
++                //"{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson", // TODO(#18886): enable for V3
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson"]
+
+   // Add additional tops for simulation.
+   sim_tops: ["spi_host_bind", "sec_cm_prim_onehot_check_bind"]
+
+   // Coverage exclusion
+-  xcelium_cov_refine_files: ["{proj_root}/hw/ip/spi_host/dv/cov/spi_host_unr_excl.vRefine"]
++  xcelium_cov_refine_files: ["{proj_root}/hw/vendor/lowrisc_ip/ip/spi_host/dv/cov/spi_host_unr_excl.vRefine"]
+
+   // Default iterations for all tests - each test entry can override this.
+   reseed: 50


### PR DESCRIPTION
This PR will address this issue: https://github.com/lowRISC/mocha/issues/428

Block level simulations (all test cases):
**dvsim hw/top_chip/dv/mocha_sim_cfgs.hjson --select-cfgs spi_host -i all**

```
## Failure Buckets
* `UVM_FATAL (uvm_phase.svh:1521) [PH_TIMEOUT] Explicit timeout of * ps hit, indicating a probable testbench issue` has 2 failures:
    * Test spi_host_stress_all has 1 failure.
        * 40.spi_host_stress_all.101738560328106606192845645493838154599283136296280726580722356108191824192258\
          Line 199, in log /home/kkoblasz/projects/mocha/scratch/kk_spi_host_dv/spi_host.sim.xcelium/40.spi_host_stress_all/latest/run.log

                UVM_FATAL @ 1000000000000 ps: (uvm_phase.svh:1521) [PH_TIMEOUT] Explicit timeout of 1000000000000 ps hit, indicating a probable testbench issue
                UVM_INFO @ 1000000000000 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                
                

    * Test spi_host_smoke has 1 failure.
        * 44.spi_host_smoke.88908516986215290608890187557760663963698610703418650725027432748659739534657\
          Line 163, in log /home/kkoblasz/projects/mocha/scratch/kk_spi_host_dv/spi_host.sim.xcelium/44.spi_host_smoke/latest/run.log

                UVM_FATAL @ 200000000000 ps: (uvm_phase.svh:1521) [PH_TIMEOUT] Explicit timeout of 200000000000 ps hit, indicating a probable testbench issue
                UVM_INFO @ 200000000000 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---

```              
               
## TOP_MOCHA_BATCH_SIM Simulation Results (Summary)
### Thursday April 23 2026 06:39:12 UTC
### Github Revision: [`8b47ef4`](https://github.com/KolosKoblasz-Semify/mocha/tree/8b47ef4fc5ed40d99064aea3cbbd1caf56597b61)
### Branch: kk_spi_host_dv

|                           Name                           |  Passing  |  Total  |  Pass Rate  |  Coverage  |
|:--------------------------------------------------------:|:---------:|:-------:|:-----------:|:----------:|
| [SPI_HOST](scratch/kk_spi_host_dv/reports/spi_host.html) |   1331    |  1335   |   99.70 %   |     --     |


          [   legend    ]: [Q: queued, D: dispatched, P: passed, F: failed, K: killed, T: total]                                                                              
00:00:06  [    build    ]: [Q: 000, D: 000, P: 001, F: 000, K: 000, T: 001] 100%                                                                                              
00:17:15  [     run     ]: [Q: 000, D: 000, P: 838, F: 002, K: 000, T: 840] 100%                                                                                              
[E 260423 07:56:34 run:947] Errors were encountered in this run.


Block level regression:

Also, nothing else is broken:
**dvsim hw/top_chip/dv/mocha_sim_cfgs.hjson -i smoke --cov**

## TOP_MOCHA_BATCH_SIM Simulation Results (Summary)
### Thursday April 23 2026 06:25:30 UTC
### Github Revision: [`8b47ef4`](https://github.com/KolosKoblasz-Semify/mocha/tree/8b47ef4fc5ed40d99064aea3cbbd1caf56597b61)
### Branch: kk_spi_host_dv

|                                           Name                                           |  Passing  |  Total  |  Pass Rate  |  Coverage  |
|:----------------------------------------------------------------------------------------:|:---------:|:-------:|:-----------:|:----------:|
|                     [UART](scratch/kk_spi_host_dv/reports/uart.html)                     |     9     |    9    |  100.00 %   |  64.40 %   |
|            [SPI_DEVICE_2P](scratch/kk_spi_host_dv/reports/spi_device_2p.html)            |     8     |    8    |  100.00 %   |  69.39 %   |
|                 [SPI_HOST](scratch/kk_spi_host_dv/reports/spi_host.html)                 |    10     |   10    |  100.00 %   |  81.81 %   |
|                 [RV_TIMER](scratch/kk_spi_host_dv/reports/rv_timer.html)                 |     3     |    3    |  100.00 %   |  67.79 %   |
|               [PRIM_ALERT](scratch/kk_spi_host_dv/reports/prim_alert.html)               |     2     |    2    |  100.00 %   |  89.80 %   |
|                 [PRIM_ESC](scratch/kk_spi_host_dv/reports/prim_esc.html)                 |     1     |    1    |  100.00 %   |  78.71 %   |
|                [PRIM_LFSR](scratch/kk_spi_host_dv/reports/prim_lfsr.html)                |     2     |    2    |  100.00 %   |  79.40 %   |
|                      [I2C](scratch/kk_spi_host_dv/reports/i2c.html)                      |     8     |    8    |  100.00 %   |  68.52 %   |
|                [XBAR_PERI](scratch/kk_spi_host_dv/reports/xbar_peri.html)                |     1     |    1    |  100.00 %   |  65.76 %   |
|                     [GPIO](scratch/kk_spi_host_dv/reports/gpio.html)                     |     9     |    9    |  100.00 %   |  75.93 %   |
|            [ROM_CTRL_32KB](scratch/kk_spi_host_dv/reports/rom_ctrl_32kb.html)            |     0     |    3    |   0.00 %    |     --     |
| [RV_DM_USE_JTAG_INTERFACE](scratch/kk_spi_host_dv/reports/rv_dm_use_jtag_interface.html) |     0     |    7    |   0.00 %    |     --     |
|            [TOP_MOCHA_SIM](scratch/kk_spi_host_dv/reports/top_mocha_sim.html)            |    18     |   21    |   85.71 %   |  59.88 %   |


          [   legend    ]: [Q: queued, D: dispatched, P: passed, F: failed, K: killed, T: total]                                                            
00:02:08  [    build    ]: [Q: 00, D: 00, P: 20, F: 04, K: 00, T: 24] 100%                                                                                  
00:06:29  [     run     ]: [Q: 00, D: 00, P: 43, F: 03, K: 10, T: 56] 100%                                                                                  
00:06:34  [  cov_merge  ]: [Q: 00, D: 00, P: 11, F: 00, K: 02, T: 13] 100%                                                                                  
00:06:50  [ cov_report  ]: [Q: 00, D: 00, P: 11, F: 00, K: 02, T: 13] 100%  