### PR TITLE
[hw] DRAM tag base and mask fixed

### DIFF
--- a/hw/top_chip/dv/verilator/dram_wrapper_sim.sv
+++ b/hw/top_chip/dv/verilator/dram_wrapper_sim.sv
@@ -13,7 +13,7 @@ module dram_wrapper_sim (
   output top_pkg::axi_dram_resp_t axi_resp_o
 );
   // Local parameters
-  localparam int unsigned ExtMemAddrWidth = $clog2(top_pkg::DRAMLength / (top_pkg::AxiDataWidth / 8));
+  localparam int unsigned ExtMemAddrWidth = $clog2(top_pkg::DRAMPhysicalLength / (top_pkg::AxiDataWidth / 8));
 
   // 64-bit memory format signals
   logic                                 ext_mem_req;

--- a/hw/top_chip/rtl/top_chip_system.sv
+++ b/hw/top_chip/rtl/top_chip_system.sv
@@ -116,7 +116,7 @@ module top_chip_system #(
     '{ idx: top_pkg::SRAM,       start_addr: top_pkg::SRAMBase,       end_addr: top_pkg::SRAMBase       + top_pkg::SRAMLength       },
     '{ idx: top_pkg::Mailbox,    start_addr: top_pkg::MailboxBase,    end_addr: top_pkg::MailboxBase    + top_pkg::MailboxLength    },
     '{ idx: top_pkg::TlCrossbar, start_addr: top_pkg::TlCrossbarBase, end_addr: top_pkg::TlCrossbarBase + top_pkg::TlCrossbarLength },
-    '{ idx: top_pkg::DRAM,       start_addr: top_pkg::DRAMBase,       end_addr: top_pkg::DRAMBase       + top_pkg::DRAMLength       }
+    '{ idx: top_pkg::DRAM,       start_addr: top_pkg::DRAMBase,       end_addr: top_pkg::DRAMBase       + top_pkg::DRAMUsableLength }
   };
 
   // TileLink signals.
@@ -1011,7 +1011,7 @@ module top_chip_system #(
   // Instantiate CHERI tag controller for DRAM
   axi_tagctrl_reg_wrap #(
     .DRAMMemBase      ( 32'(top_pkg::DRAMBase)            ),
-    .DRAMMemLength    ( 32'(top_pkg::DRAMLength)          ),
+    .DRAMMemLength    ( 32'(top_pkg::DRAMPhysicalLength)  ),
     .CapSize          ( top_pkg::CapSizeBits              ),
     .TagCacheMemBase  ( 32'(top_pkg::TagCacheMemBase)     ),
     .SetAssociativity ( top_pkg::TagCacheSetAssociativity ),

--- a/hw/top_chip/rtl/top_chip_system.sv
+++ b/hw/top_chip/rtl/top_chip_system.sv
@@ -76,11 +76,21 @@ module top_chip_system #(
   // CVA6 configuration
   function automatic config_pkg::cva6_cfg_t build_cva6_config(config_pkg::cva6_user_cfg_t CVA6UserCfg);
     config_pkg::cva6_user_cfg_t cfg = CVA6UserCfg;
-    cfg.RVZiCond              = bit'(0);
-    cfg.CvxifEn               = bit'(0);
-    cfg.NrNonIdempotentRules  = unsigned'(1);
-    cfg.NonIdempotentAddrBase = 1024'({64'b0});
-    cfg.NonIdempotentLength   = 1024'({top_pkg::SRAMBase});
+    cfg.RVZiCond                    = bit'(0);
+    cfg.CvxifEn                     = bit'(0);
+    cfg.DmBaseAddress               = top_pkg::DebugMemBase;
+    cfg.NrExecuteRegionRules        = unsigned'(4);
+    cfg.ExecuteRegionAddrBase       = 1024'({top_pkg::DRAMBase,
+                                             top_pkg::DebugMemBase,
+                                             top_pkg::SRAMBase,
+                                             top_pkg::RomCtrlMemBase});
+    cfg.ExecuteRegionLength         = 1024'({top_pkg::DRAMUsableLength,
+                                             top_pkg::DebugMemLength,
+                                             top_pkg::SRAMLength,
+                                             top_pkg::RomCtrlMemLength});
+    cfg.NrCachedRegionRules         = unsigned'(1);
+    cfg.CachedRegionAddrBase        = 1024'({top_pkg::DRAMBase});
+    cfg.CachedRegionLength          = 1024'({top_pkg::DRAMUsableLength});
     return build_config_pkg::build_config(cfg);
   endfunction
 

--- a/hw/top_chip/rtl/top_pkg.sv
+++ b/hw/top_chip/rtl/top_pkg.sv
@@ -37,6 +37,7 @@ package top_pkg;
   typedef enum longint unsigned {
     RomCtrlMemBase = 64'h0008_0000,
     SRAMBase       = 64'h1000_0000,
+    DebugMemBase   = 64'h2000_0000,
     MailboxBase    = 64'h2001_0000,
     TlCrossbarBase = 64'h4000_0000,
     DRAMBase       = 64'h8000_0000
@@ -45,6 +46,7 @@ package top_pkg;
   // Memory lengths
   localparam longint unsigned RomCtrlMemLength   = 64'h0000_8000;
   localparam longint unsigned SRAMLength         = 64'h0002_0000;
+  localparam longint unsigned DebugMemLength     = 64'h0000_1000;
   localparam longint unsigned MailboxLength      = 64'h0001_0000;
   localparam longint unsigned TlCrossbarLength   = 64'h1000_0000;
   localparam longint unsigned DRAMPhysicalLength = 64'h4000_0000;

--- a/hw/top_chip/rtl/top_pkg.sv
+++ b/hw/top_chip/rtl/top_pkg.sv
@@ -42,22 +42,25 @@ package top_pkg;
     DRAMBase       = 64'h8000_0000
   } axi_addr_start_t;
 
-  localparam longint unsigned RomCtrlMemLength  = 64'h0000_8000;
-  localparam longint unsigned SRAMLength        = 64'h0002_0000;
-  localparam longint unsigned MailboxLength     = 64'h0001_0000;
-  localparam longint unsigned TlCrossbarLength  = 64'h1000_0000;
-  localparam longint unsigned DRAMLength        = 64'h3F80_0000;
+  // Memory lengths
+  localparam longint unsigned RomCtrlMemLength   = 64'h0000_8000;
+  localparam longint unsigned SRAMLength         = 64'h0002_0000;
+  localparam longint unsigned MailboxLength      = 64'h0001_0000;
+  localparam longint unsigned TlCrossbarLength   = 64'h1000_0000;
+  localparam longint unsigned DRAMPhysicalLength = 64'h4000_0000;
 
-  localparam longint unsigned RomCtrlMemMask    = RomCtrlMemLength - 1;
-  localparam longint unsigned SRAMMask          = SRAMLength - 1;
-  localparam longint unsigned MailboxMask       = MailboxLength - 1;
-  localparam longint unsigned TlCrossbarMask    = TlCrossbarLength - 1;
-  localparam longint unsigned DRAMMask          = DRAMLength - 1;
+  // Memory address masks
+  localparam longint unsigned RomCtrlMemMask = RomCtrlMemLength - 1;
+  localparam longint unsigned SRAMMask       = SRAMLength - 1;
+  localparam longint unsigned MailboxMask    = MailboxLength - 1;
+  localparam longint unsigned TlCrossbarMask = TlCrossbarLength - 1;
+  localparam longint unsigned DRAMMask       = DRAMPhysicalLength - 1;
 
   // Tag controller parameters
   localparam int     unsigned CapSizeBits              = 128;
-  localparam longint unsigned TagCacheMemLength        = DRAMLength >> $clog2(CapSizeBits);
-  localparam longint unsigned TagCacheMemBase          = DRAMBase + DRAMLength - TagCacheMemLength;
+  localparam longint unsigned TagCacheMemLength        = DRAMPhysicalLength >> $clog2(CapSizeBits);
+  localparam longint unsigned DRAMUsableLength         = DRAMPhysicalLength - TagCacheMemLength;
+  localparam longint unsigned TagCacheMemBase          = DRAMBase + DRAMUsableLength;
   localparam int     unsigned TagCacheSetAssociativity = 8;
   localparam int     unsigned TagCacheNumLines         = 128; // Number of cache lines in each set
   localparam int     unsigned TagCacheNumBlocks        = 4;   // Number of words in a cache line


### PR DESCRIPTION
Previously we had conflated the ideas of the actual physical length of DRAM and the DRAM length minus the tag store. This caused multiple issues in the design.

Closes: https://github.com/lowRISC/mocha/issues/471