### PR TITLE
FPGA Runner: Remove timeout handling, add `run` subcommand

### DIFF
--- a/doc/ref/dev_guide.md
+++ b/doc/ref/dev_guide.md
@@ -189,7 +189,7 @@ openFPGALoader -b genesys2 build/lowrisc_mocha_chip_mocha_genesys2_0/synth-vivad
 
 Then, to load and run a single software binary on FPGA, first build the software, then run:
 ```sh
-./util/fpga_runner.py build/sw/device/examples/hello_world
+./util/fpga_runner.py run build/sw/device/examples/hello_world
 ```
 
 Or, to run all the FPGA tests, first build the software, then run:

--- a/sw/cmake/opensbi.cmake
+++ b/sw/cmake/opensbi.cmake
@@ -93,7 +93,7 @@ function(mocha_opensbi_with_payload_test PAYLOAD_TARGET)
 
   add_test(
       NAME ${NAME}_fpga_genesys2
-      COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py ${NAME}/fw_payload.elf
+      COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py test ${NAME}/fw_payload.elf
   )
 
   set_property(TEST ${NAME}_sim_verilator PROPERTY TIMEOUT 7200)

--- a/sw/cmake/tests.cmake
+++ b/sw/cmake/tests.cmake
@@ -69,7 +69,7 @@ function(mocha_add_fpga_test)
     set(TEST ${arg_NAME}_fpga_genesys2)
     add_test(
         NAME ${TEST} 
-        COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py ${arg_NAME}
+        COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py test ${arg_NAME}
     )
     set_tests_properties(${TEST} PROPERTIES TIMEOUT ${arg_TIMEOUT})
 endfunction()

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -42,14 +42,14 @@ async def set_pin(pin: int, val: bool) -> None:
             print(f"[{RUNNER}] gpio-write command exited with non-zero exit code {p.returncode}")
             sys.exit(1)
     except TimeoutError:
-        print(f"[{RUNNER}] gpio-write timed out after {FTDITOOL_WAIT_TIME} seconds.")
+        print(f"[{RUNNER}] gpio-write timed out after {FTDITOOL_WAIT_TIME} seconds")
         await p.terminate()  # or maybe p.kill()
         sys.exit(1)
 
 
 async def reset_core() -> None:
     """
-    Pull the reset pin down for 100ms.
+    Reset the core by pulling the reset pin down for 100ms.
     """
     await set_pin(2, False)
     await asyncio.sleep(0.1)
@@ -79,13 +79,11 @@ def get_load_addr(elf: Path) -> int:
                 seg["p_paddr"] for seg in elf.iter_segments() if seg["p_type"] == "PT_LOAD"
             ]
             if not load_addrs:
-                print(f"[{RUNNER}] no `PT_LOAD` segments found in elf {elf}")
+                print(f"[{RUNNER}] no PT_LOAD segments found in ELF file {elf}")
                 sys.exit(1)
-
-            first_address = min(load_addrs)
-            return first_address
+            return min(load_addrs)
     except OSError as e:
-        print(f"[{RUNNER}] error opening elf {elf}: {e}")
+        print(f"[{RUNNER}] error opening ELF file {elf}: {e}")
         sys.exit(1)
 
 

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -22,17 +22,18 @@ MOCHA_BOOTROM_BOOSTRAP_STR = "Entering SPI bootstrap"
 RUNNER: str = Path(__file__).name
 
 
-async def set_pin(pin: int, val: int) -> None:
+async def set_pin(pin: int, val: bool) -> None:
     command = [
         "ftditool",
         "--pid",
         hex(FTDI_PID),
         "gpio-write",
         str(pin),
-        str(val),
+        str(int(val)),
         "--ftdi",
         FTDI_DEVICE_DESC,
     ]
+
     p = await asyncio.create_subprocess_exec(*command)
     try:
         res = await asyncio.wait_for(p.wait(), FTDITOOL_WAIT_TIME)
@@ -49,21 +50,20 @@ async def reset_core() -> None:
     """
     Pull the reset pin down for 100ms.
     """
-    await set_pin(2, 0)
+    await set_pin(2, False)
     await asyncio.sleep(0.1)
-    await set_pin(2, 1)
+    await set_pin(2, True)
 
 
-async def bootstrap(uart: serial.Serial) -> bool:
+async def bootstrap(uart: serial.Serial) -> None:
     """
     Pull down the bootstrap pin, reset the core, wait for the bootstrap string over uart,
     then release the pin the bootstrap pin.
     """
-    await set_pin(0, 0)
+    await set_pin(0, False)
     await reset_core()
-    result = await poll_uart_checking_for(uart, MOCHA_BOOTROM_BOOSTRAP_STR)
-    await set_pin(0, 1)
-    return result is not None
+    await poll_uart_checking_for(uart, MOCHA_BOOTROM_BOOSTRAP_STR)
+    await set_pin(0, True)
 
 
 def get_load_addr(elf: Path) -> int:

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -17,7 +17,8 @@ FTDI_PID: int = 0x6010
 BAUD_RATE: int = 1_000_000
 FTDITOOL_WAIT_TIME: int = 60
 FTDI_DEVICE_DESC = "Digilent"
-MOCHA_BOOTROM_BOOSTRAP_STR = "Entering SPI bootstrap"
+MOCHA_BOOTSTAP_PATTERN = re.compile(r"Entering SPI bootstrap")
+TEST_PATTERN = re.compile(r"TEST RESULT: (PASSED|FAILED)", re.IGNORECASE)
 
 RUNNER: str = Path(__file__).name
 
@@ -55,14 +56,18 @@ async def reset_core() -> None:
     await set_pin(2, True)
 
 
-async def bootstrap(uart: serial.Serial) -> None:
+async def bootstrap(uart: serial.Serial | None) -> None:
     """
-    Pull down the bootstrap pin, reset the core, wait for the bootstrap string over uart,
-    then release the pin the bootstrap pin.
+    Pull down the bootstrap pin and reset the core. If a UART is provided,
+    wait for the bootstrap string over UART, otherwise wait a short period
+    of time and assume the system is ready for bootstrapping. Then release the pin.
     """
     await set_pin(0, False)
     await reset_core()
-    await poll_uart_checking_for(uart, MOCHA_BOOTROM_BOOSTRAP_STR)
+    if uart is not None:
+        await poll_uart_checking_for(uart, MOCHA_BOOTSTAP_PATTERN)
+    else:
+        await asyncio.sleep(0.5)
     await set_pin(0, True)
 
 
@@ -84,36 +89,31 @@ def get_load_addr(elf: Path) -> int:
         sys.exit(1)
 
 
-async def load_fpga_test(test: Path, uart) -> None:
+async def load_fpga_binary(path: Path, uart: serial.Serial | None) -> None:
+    load_address = get_load_addr(path)
+
     await bootstrap(uart)
+
     command = [
         "ftditool",
         "--pid",
         hex(FTDI_PID),
         "bootstrap",
         "--addr",
-        hex(get_load_addr(test)),
+        hex(load_address),
         "--skip-erase",
         "--ftdi",
         FTDI_DEVICE_DESC,
     ]
-    command.append(str(test.with_suffix(".bin")))
+    command.append(str(path.with_suffix(".bin")))
+
     p = await asyncio.create_subprocess_exec(*command)
     if await p.wait() != 0:
         print(f"[{RUNNER}] SPI load command exited with non-zero exit code {p.returncode}")
         sys.exit(1)
 
 
-async def run_fpga_test(tty: str, test: Path) -> bool:
-    with serial.Serial(tty, BAUD_RATE, timeout=0) as uart:
-        await load_fpga_test(test, uart)
-        pattern = r"TEST RESULT: (PASSED|FAILED)"
-        result = await asyncio.create_task(poll_uart_checking_for(uart, pattern))
-        return "PASSED" in result
-
-
-async def poll_uart_checking_for(uart: serial.Serial, pattern: str) -> str:
-    pattern = re.compile(pattern, re.IGNORECASE)
+async def poll_uart_checking_for(uart: serial.Serial, pattern: re.Pattern) -> str:
     while True:
         line = await asyncio.to_thread(uart.readline)
         line = line.decode("utf-8", errors="ignore")
@@ -131,20 +131,61 @@ def find_uart(vid: int = 0x0403, pid: int = 0x6001) -> str | None:
     return None
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="FPGA test runner")
-    parser.add_argument("test", type=Path, help="path to test")
-    args = parser.parse_args()
-
+async def do_fpga_test(args) -> None:
+    """
+    Test subcommand.
+    Load the binary onto the FPGA, then poll for the test result pattern.
+    """
     if uart_tty := find_uart():
-        try:
-            success = asyncio.run(run_fpga_test(uart_tty, args.test))
-            sys.exit(0 if success else 1)
-        except KeyboardInterrupt:
+        with serial.Serial(uart_tty, BAUD_RATE, timeout=0) as uart:
+            await load_fpga_binary(args.path, uart)
+            result = await poll_uart_checking_for(uart, TEST_PATTERN)
+            if "PASSED" in result:
+                sys.exit(0)  # test success
             sys.exit(1)
 
     print(f"[{RUNNER}] Error: UART device not found")
     sys.exit(1)
+
+
+async def do_fpga_run(args) -> None:
+    """
+    Run subcommand.
+    Just load the binary onto the FPGA without opening the UART,
+    so that it can remain open in a separate application (e.g screen).
+    """
+    await load_fpga_binary(args.path, None)
+    sys.exit(0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="FPGA test runner")
+    subparsers = parser.add_subparsers(dest="command", required=True, help="Subcommands")
+
+    test_help = (
+        "Load a binary on the FPGA, then poll the UART for a test result. "
+        "Captures output from the UART."
+    )
+
+    test_parser = subparsers.add_parser("test", help=test_help, description=("test: " + test_help))
+    test_parser.add_argument("path", type=Path, help="Path to test ELF to test on the FPGA")
+    test_parser.set_defaults(func=do_fpga_test)
+
+    run_help = (
+        "Load a binary on the FPGA, then exit. This subcommand does not use the UART, "
+        "so that it can be kept open in a separate program (e.g screen, picocom) for "
+        "interactive use."
+    )
+
+    run_parser = subparsers.add_parser("run", help=run_help, description=("run: " + run_help))
+    run_parser.add_argument("path", type=Path, help="Path to program ELF to load on the FPGA")
+    run_parser.set_defaults(func=do_fpga_run)
+
+    args = parser.parse_args()
+    try:
+        asyncio.run(args.func(args))
+    except KeyboardInterrupt:  # Suppress error traceback if interrupted by user with ctrl-c.
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -7,7 +7,6 @@ import argparse
 import asyncio
 import re
 import sys
-import time
 from pathlib import Path
 
 import serial
@@ -16,7 +15,6 @@ from elftools.elf.elffile import ELFFile
 
 FTDI_PID: int = 0x6010
 BAUD_RATE: int = 1_000_000
-TIMEOUT: int = 60
 FTDITOOL_WAIT_TIME: int = 60
 FTDI_DEVICE_DESC = "Digilent"
 MOCHA_BOOTROM_BOOSTRAP_STR = "Entering SPI bootstrap"
@@ -111,13 +109,12 @@ async def run_fpga_test(tty: str, test: Path) -> bool:
         await load_fpga_test(test, uart)
         pattern = r"TEST RESULT: (PASSED|FAILED)"
         result = await asyncio.create_task(poll_uart_checking_for(uart, pattern))
-        return result and "PASSED" in result
+        return "PASSED" in result
 
 
-async def poll_uart_checking_for(uart: serial.Serial, pattern: str) -> str | None:
+async def poll_uart_checking_for(uart: serial.Serial, pattern: str) -> str:
     pattern = re.compile(pattern, re.IGNORECASE)
-    start = time.time()
-    while time.time() - start < TIMEOUT:
+    while True:
         line = await asyncio.to_thread(uart.readline)
         line = line.decode("utf-8", errors="ignore")
         print(line, end="")
@@ -125,8 +122,6 @@ async def poll_uart_checking_for(uart: serial.Serial, pattern: str) -> str | Non
             continue
         if match := pattern.search(line):
             return match.group()
-    print(f"[{RUNNER}] Test timeout")
-    return None
 
 
 def find_uart(vid: int = 0x0403, pid: int = 0x6001) -> str | None:


### PR DESCRIPTION
This PR makes some changes to the FPGA runner.

Test timeout handling is removed as this functionality is now handled by CMake/CTest, so the runner can be simplified to not do this itself.

This PR also moves the testing aspect of the runner to a `test` subcommand, and introduces a `run` subcommand which just loads a program over SPI and exits. This is useful for simply loading and running interactive software, such as examples and demos, and in the future interactive Operating Systems. This subcommand does not attempt to open the UART, which means that the UART can be kept open continuously across reboots in a serial console e.g screen or picocom, which is quite convenient.