### PR TITLE
[fpga] Remove duplicate RomInitFile parameter

### DIFF
--- a/hw/top_chip/chip_mocha_genesys2.core
+++ b/hw/top_chip/chip_mocha_genesys2.core
@@ -30,19 +30,13 @@ filesets:
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
-  # --RomInitFile=$PWD/sw/device/examples/hello_world/hello_world.vmem
+  # --RomInitFile=$PWD/sw/device/examples/hello_world.vmem
   # XXX: The VMEM file should be added to the sources of the Vivado project to
   # make the Vivado dependency tracking work. However this requires changes to
   # fusesoc first.
   RomInitFile:
     datatype: str
-    description: Boot ROM initialization file in 64 bit vmem hex format
-    default: ""
-    paramtype: vlogparam
-
-  RomInitFile:
-    datatype: str
-    description: ROM initialization file in 32 bit vmem hex format
+    description: Boot ROM initialization file in 32 bit vmem hex format
     default: ""
     paramtype: vlogparam
 
@@ -59,7 +53,6 @@ targets:
       - files_constraints
     toplevel: chip_mocha_genesys2
     parameters:
-      - RomInitFile
       - RomInitFile
     tools:
       vivado:


### PR DESCRIPTION
This removes the duplicate `RomInitFile` parameter in the chip top core file.