### PR TITLE
[rstmgr,dv] Reset Manager DV ported to mocha

### DIFF
--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -30,6 +30,7 @@
     "{proj_root}/hw/vendor/lowrisc_ip/ip/i2c/dv/i2c_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+    "{proj_root}/hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/tmp_sim_cfg/rv_dm_use_jtag_interface_sim_cfg.hjson",
 

--- a/hw/top_chip/ip_autogen/rstmgr/data/rstmgr_testplan.hjson
+++ b/hw/top_chip/ip_autogen/rstmgr/data/rstmgr_testplan.hjson
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "rstmgr"
-  import_testplans: ["hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
+  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
                      "rstmgr_sec_cm_testplan.hjson"]
 
   testpoints: [

--- a/hw/top_chip/ip_autogen/rstmgr/dv/env/rstmgr_if.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/env/rstmgr_if.sv
@@ -65,5 +65,5 @@ interface rstmgr_if (
   always_comb cpu_info_en = `PATH_TO_DUT.reg2hw.cpu_info_ctrl.en.q;
 
   bit rst_ni_inactive;
-  always_comb rst_ni_inactive = resets_o.rst_lc_io_n[rstmgr_pkg::DomainMainSel];
+  always_comb rst_ni_inactive = resets_o.rst_io_n[rstmgr_pkg::DomainMainSel];
 endinterface

--- a/hw/top_chip/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
@@ -115,8 +115,8 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
     expected_cpu_enable = 0;
 
     cfg.clk_rst_vif.wait_clks(8);
-    // Wait till rst_lc_n is inactive for non-aon.
-    `DV_WAIT(cfg.rstmgr_vif.resets_o.rst_lc_n[1])
+    // Wait till rst_io_n is inactive for non-aon.
+    `DV_WAIT(cfg.rstmgr_vif.resets_o.rst_io_n[1])
 
     check_reset_info(get_reset_code(start_reset, 0), {reset_name[start_reset], " reset"});
     check_alert_info_after_reset(expected_alert_dump, expected_alert_enable);
@@ -172,7 +172,7 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
       reset_done();
 
       cfg.io_clk_rst_vif.wait_clks(8);
-      wait(cfg.rstmgr_vif.resets_o.rst_lc_n[1]);
+      wait(cfg.rstmgr_vif.resets_o.rst_io_n[1]);
       check_reset_info(expected_reset_info_code);
       check_alert_info_after_reset(.alert_dump(expected_alert_dump),
                                    .enable(expected_alert_enable));

--- a/hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -21,7 +21,7 @@
   testplan: "{self_dir}/data/rstmgr_cnsty_chk_testplan.hjson"
 
   // Import additional common sim cfg files.
-  import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson"]
 
 
   // Specific exclusion files.

--- a/hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:mocha_dv:rstmgr_sim:0.1
@@ -25,16 +25,16 @@
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 // Just run the stress_all sequence, and don't inject random
                 // resets since we may get overlapping resets due to sequences
                 // that inject them.
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_all_test.hjson"
                 ]
 
   // Specific exclusion files.

--- a/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -158,17 +158,21 @@ interface rstmgr_cascading_sva_if (
   `CASCADED_ASSERTS(CascadeEffAonToRstPorMain, effective_aon_rst_n[rstmgr_pkg::DomainAonSel],
                     resets_o.rst_por_n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_main_i)
 
-  // Controlled by rst_lc_src_n.
-  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
-                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
-  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
-
   // Controlled by rst_sys_src_n.
-  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeSysToMain_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+
+  `CASCADED_ASSERTS(CascadeSysToIO_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+
+  `CASCADED_ASSERTS(CascadeSysToSPIHost_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+
+  `CASCADED_ASSERTS(CascadeSysToSPIDevice_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+
+  `CASCADED_ASSERTS(CascadeSysToI2C_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
 
   `undef FALL_ASSERT
   `undef RISE_ASSERTS

--- a/hw/top_chip/ip_autogen/rstmgr/dv/tb.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/tb.sv
@@ -40,7 +40,7 @@ module tb;
 
   tl_if tl_if (
     .clk,
-    .rst_n(rstmgr_if.resets_o.rst_lc_io_n[rstmgr_pkg::DomainMainSel])
+    .rst_n(rstmgr_if.resets_o.rst_io_n[rstmgr_pkg::DomainMainSel])
   );
 
   rstmgr_if rstmgr_if (
@@ -63,7 +63,7 @@ module tb;
   // This is consistent with rstmgr being the only source of resets.
   rstmgr dut (
     .clk_i        (clk),
-    .rst_ni       (rstmgr_if.resets_o.rst_lc_io_n[rstmgr_pkg::DomainMainSel]),
+    .rst_ni       (rstmgr_if.resets_o.rst_io_n[rstmgr_pkg::DomainMainSel]),
     .clk_aon_i    (clk_aon),
     .clk_io_i     (clk_io),
     .clk_main_i   (clk_main),
@@ -118,7 +118,7 @@ module tb;
     // This may help any code that depends on clk_rst_vif.rst_n in the infrastructure: they won't
     // be able to change but at least the reset value will be true to the environment.
     clk_rst_if.drive_rst_n = 1'b0;
-    force clk_rst_if.rst_n = rstmgr_if.resets_o.rst_lc_io_n[rstmgr_pkg::DomainMainSel];
+    force clk_rst_if.rst_n = rstmgr_if.resets_o.rst_io_n[rstmgr_pkg::DomainMainSel];
   end
 
 endmodule

--- a/hw/vendor/lowrisc_ip.vendor.hjson
+++ b/hw/vendor/lowrisc_ip.vendor.hjson
@@ -45,7 +45,7 @@
     {from: "hw/ip_templates/clkmgr",        to: "ip_templates/clkmgr"},
     {from: "hw/ip_templates/gpio",          to: "ip_templates/gpio", patch_dir: "gpio"}, // General purpose I/O
     {from: "hw/ip_templates/pwrmgr",        to: "ip_templates/pwrmgr", patch_dir: "pwrmgr"},
-    {from: "hw/ip_templates/rstmgr",        to: "ip_templates/rstmgr"},
+    {from: "hw/ip_templates/rstmgr",        to: "ip_templates/rstmgr", patch_dir: "rstmgr"},
     {from: "hw/ip_templates/rv_plic",       to: "ip_templates/rv_plic"},
 
     // Primitives.

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/data/rstmgr_testplan.hjson
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/data/rstmgr_testplan.hjson
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "rstmgr"
-  import_testplans: ["hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
+  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
                      "rstmgr_sec_cm_testplan.hjson"]
 
   testpoints: [

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/env/rstmgr_if.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/env/rstmgr_if.sv.tpl
@@ -13,7 +13,7 @@ elif "io" in all_clks:
 else:
     assert 0, "No preferred clock available"
 
-preferred_rst_n = f"rst_lc_{preferred_domain}_n"
+preferred_rst_n = f"rst_{preferred_domain}_n"
 %>\
 
 interface rstmgr_if (

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv.tpl
@@ -127,8 +127,8 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
     expected_cpu_enable = 0;
 
     cfg.clk_rst_vif.wait_clks(8);
-    // Wait till rst_lc_n is inactive for non-aon.
-    `DV_WAIT(cfg.rstmgr_vif.resets_o.rst_lc_n[1])
+    // Wait till rst_io_n is inactive for non-aon.
+    `DV_WAIT(cfg.rstmgr_vif.resets_o.rst_io_n[1])
 
     check_reset_info(get_reset_code(start_reset, 0), {reset_name[start_reset], " reset"});
     check_alert_info_after_reset(expected_alert_dump, expected_alert_enable);
@@ -184,7 +184,7 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
       reset_done();
 
       cfg.${preferred_clk_rst_vif}.wait_clks(8);
-      wait(cfg.rstmgr_vif.resets_o.rst_lc_n[1]);
+      wait(cfg.rstmgr_vif.resets_o.rst_io_n[1]);
       check_reset_info(expected_reset_info_code);
       check_alert_info_after_reset(.alert_dump(expected_alert_dump),
                                    .enable(expected_alert_enable));

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
@@ -21,7 +21,7 @@
   testplan: "{self_dir}/data/rstmgr_cnsty_chk_testplan.hjson"
 
   // Import additional common sim cfg files.
-  import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson"]
 
 
   // Specific exclusion files.

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: ${instance_vlnv("lowrisc:dv:rstmgr_sim:0.1")}
@@ -25,16 +25,16 @@
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 // Just run the stress_all sequence, and don't inject random
                 // resets since we may get overlapping resets due to sequences
                 // that inject them.
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_all_test.hjson"
                 ]
 
   // Specific exclusion files.

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
@@ -183,17 +183,21 @@ interface rstmgr_cascading_sva_if (
                     resets_o.rst_por_${clk + "_" if clk != "main" else ""}n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_${clk}_i)
 % endfor
 
-  // Controlled by rst_lc_src_n.
-  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
-                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
-  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
-
   // Controlled by rst_sys_src_n.
-  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeSysToMain_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+
+  `CASCADED_ASSERTS(CascadeSysToIO_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+
+  `CASCADED_ASSERTS(CascadeSysToSPIHost_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+
+  `CASCADED_ASSERTS(CascadeSysToSPIDevice_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+
+  `CASCADED_ASSERTS(CascadeSysToI2C_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
 
   `undef FALL_ASSERT
   `undef RISE_ASSERTS

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/tb.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/tb.sv.tpl
@@ -12,7 +12,7 @@ elif "io" in all_clks:
 else:
     assert 0, "No preferred clock available"
 
-preferred_rst_n = f"rst_lc_{preferred_domain}_n"
+preferred_rst_n = f"rst_{preferred_domain}_n"
 preferred_por_n = f"rst_por_{preferred_domain}_n"
 %>\
 module tb;

--- a/hw/vendor/patches/lowrisc_ip/rstmgr/0001_Fix_Paths_And_Tools.patch
+++ b/hw/vendor/patches/lowrisc_ip/rstmgr/0001_Fix_Paths_And_Tools.patch
@@ -1,0 +1,73 @@
+diff --git a/data/rstmgr_testplan.hjson b/data/rstmgr_testplan.hjson
+index be44e83..0fdfd52 100644
+--- a/data/rstmgr_testplan.hjson
++++ b/data/rstmgr_testplan.hjson
+@@ -3,12 +3,12 @@
+ // SPDX-License-Identifier: Apache-2.0
+ {
+   name: "rstmgr"
+-  import_testplans: ["hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
++  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
+                      "rstmgr_sec_cm_testplan.hjson"]
+
+   testpoints: [
+
+diff --git a/dv/rstmgr_sim_cfg.hjson.tpl b/dv/rstmgr_sim_cfg.hjson.tpl
+index b12e73a..3c50439 100644
+--- a/dv/rstmgr_sim_cfg.hjson.tpl
++++ b/dv/rstmgr_sim_cfg.hjson.tpl
+@@ -12,7 +12,7 @@
+   tb: tb
+
+   // Simulator used to sign off this block
+-  tool: vcs
++  tool: xcelium
+
+   // Fusesoc core file used for building the file list.
+   fusesoc_core: ${instance_vlnv("lowrisc:dv:rstmgr_sim:0.1")}
+@@ -25,16 +25,16 @@
+
+   // Import additional common sim cfg files.
+   import_cfgs: [// Project wide common sim cfg file
+-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
+                 // Common CIP test lists
+-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                 // Just run the stress_all sequence, and don't inject random
+                 // resets since we may get overlapping resets due to sequences
+                 // that inject them.
+-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_all_test.hjson"
+                 ]
+
+   // Specific exclusion files.
+diff --git a/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl b/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
+index 42f8b22..1107fe8 100644
+--- a/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
++++ b/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
+@@ -21,7 +21,7 @@
+   testplan: "{self_dir}/data/rstmgr_cnsty_chk_testplan.hjson"
+
+   // Import additional common sim cfg files.
+-  import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
++  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson"]
+
+
+   // Specific exclusion files.

--- a/hw/vendor/patches/lowrisc_ip/rstmgr/0002_Fix_Templates.patch
+++ b/hw/vendor/patches/lowrisc_ip/rstmgr/0002_Fix_Templates.patch
@@ -1,0 +1,86 @@
+diff --git a/dv/env/rstmgr_if.sv.tpl b/dv/env/rstmgr_if.sv.tpl
+index cb2102d..25c6fe2 100644
+--- a/dv/env/rstmgr_if.sv.tpl
++++ b/dv/env/rstmgr_if.sv.tpl
+@@ -13,7 +13,7 @@ elif "io" in all_clks:
+ else:
+     assert 0, "No preferred clock available"
+ 
+-preferred_rst_n = f"rst_lc_{preferred_domain}_n"
++preferred_rst_n = f"rst_{preferred_domain}_n"
+ %>\
+ 
+ interface rstmgr_if (
+diff --git a/dv/env/seq_lib/rstmgr_reset_vseq.sv.tpl b/dv/env/seq_lib/rstmgr_reset_vseq.sv.tpl
+index 356807f..1670853 100644
+--- a/dv/env/seq_lib/rstmgr_reset_vseq.sv.tpl
++++ b/dv/env/seq_lib/rstmgr_reset_vseq.sv.tpl
+@@ -127,8 +127,8 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
+     expected_cpu_enable = 0;
+ 
+     cfg.clk_rst_vif.wait_clks(8);
+-    // Wait till rst_lc_n is inactive for non-aon.
+-    `DV_WAIT(cfg.rstmgr_vif.resets_o.rst_lc_n[1])
++    // Wait till rst_io_n is inactive for non-aon.
++    `DV_WAIT(cfg.rstmgr_vif.resets_o.rst_io_n[1])
+ 
+     check_reset_info(get_reset_code(start_reset, 0), {reset_name[start_reset], " reset"});
+     check_alert_info_after_reset(expected_alert_dump, expected_alert_enable);
+@@ -184,7 +184,7 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
+       reset_done();
+ 
+       cfg.${preferred_clk_rst_vif}.wait_clks(8);
+-      wait(cfg.rstmgr_vif.resets_o.rst_lc_n[1]);
++      wait(cfg.rstmgr_vif.resets_o.rst_io_n[1]);
+       check_reset_info(expected_reset_info_code);
+       check_alert_info_after_reset(.alert_dump(expected_alert_dump),
+                                    .enable(expected_alert_enable));
+diff --git a/dv/sva/rstmgr_cascading_sva_if.sv.tpl b/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+index 143d0ed..1653cb6 100644
+--- a/dv/sva/rstmgr_cascading_sva_if.sv.tpl
++++ b/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+@@ -183,17 +183,21 @@ interface rstmgr_cascading_sva_if (
+                     resets_o.rst_por_${clk + "_" if clk != "main" else ""}n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_${clk}_i)
+ % endfor
+ 
+-  // Controlled by rst_lc_src_n.
+-  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
+-                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
+-  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+-                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+-
+   // Controlled by rst_sys_src_n.
+-  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+-                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+-  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+-                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
++  `CASCADED_ASSERTS(CascadeSysToMain_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
++
++  `CASCADED_ASSERTS(CascadeSysToIO_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
++
++  `CASCADED_ASSERTS(CascadeSysToSPIHost_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
++
++  `CASCADED_ASSERTS(CascadeSysToSPIDevice_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
++
++  `CASCADED_ASSERTS(CascadeSysToI2C_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+ 
+   `undef FALL_ASSERT
+   `undef RISE_ASSERTS
+diff --git a/dv/tb.sv.tpl b/dv/tb.sv.tpl
+index c2e8ce4..49dbb57 100644
+--- a/dv/tb.sv.tpl
++++ b/dv/tb.sv.tpl
+@@ -12,7 +12,7 @@ elif "io" in all_clks:
+ else:
+     assert 0, "No preferred clock available"
+ 
+-preferred_rst_n = f"rst_lc_{preferred_domain}_n"
++preferred_rst_n = f"rst_{preferred_domain}_n"
+ preferred_por_n = f"rst_por_{preferred_domain}_n"
+ %>\
+ module tb;


### PR DESCRIPTION
This PR ports Reset Manager Controller DV code from Opentitan to Mocha.

This PR will address: https://github.com/lowRISC/mocha/issues/433 --- Close #433 

Project specific tests: 

**dvsim hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson -i all --cov**

### Test Results

|  Stage  |                   Name                    | Tests                             |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:-----------------------------------------:|:----------------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V1    |                   smoke                   | rstmgr_smoke                      |      3.000s       |    146.644us     |    50     |   50    |  100.00 %   |
|   V1    |               csr_hw_reset                | rstmgr_csr_hw_reset               |      2.000s       |    111.996us     |     5     |    5    |  100.00 %   |
|   V1    |                  csr_rw                   | rstmgr_csr_rw                     |      2.000s       |     57.904us     |    20     |   20    |  100.00 %   |
|   V1    |               csr_bit_bash                | rstmgr_csr_bit_bash               |      6.000s       |    837.419us     |     5     |    5    |  100.00 %   |
|   V1    |               csr_aliasing                | rstmgr_csr_aliasing               |      2.000s       |    141.699us     |     5     |    5    |  100.00 %   |
|   V1    |        csr_mem_rw_with_rand_reset         | rstmgr_csr_mem_rw_with_rand_reset |      2.000s       |     97.203us     |    20     |   20    |  100.00 %   |
|   V1    | regwen_csr_and_corresponding_lockable_csr | rstmgr_csr_rw                     |      2.000s       |     57.904us     |    20     |   20    |  100.00 %   |
|   V1    | regwen_csr_and_corresponding_lockable_csr | rstmgr_csr_aliasing               |      2.000s       |    141.699us     |     5     |    5    |  100.00 %   |
|   V1    |                                           | **TOTAL**                         |                   |                  |    105    |   105   |  100.00 %   |
|   V2    |              reset_stretcher              | rstmgr_por_stretcher              |      2.000s       |    193.769us     |    50     |   50    |  100.00 %   |
|   V2    |                  sw_rst                   | rstmgr_sw_rst                     |      3.000s       |    112.860us     |    50     |   50    |  100.00 %   |
|   V2    |             sw_rst_reset_race             | rstmgr_sw_rst_reset_race          |      2.000s       |    100.244us     |    50     |   50    |  100.00 %   |
|   V2    |                reset_info                 | rstmgr_reset                      |      7.000s       |    1213.694us    |    50     |   50    |  100.00 %   |
|   V2    |                 cpu_info                  | rstmgr_reset                      |      7.000s       |    1213.694us    |    50     |   50    |  100.00 %   |
|   V2    |                alert_info                 | rstmgr_reset                      |      7.000s       |    1213.694us    |    50     |   50    |  100.00 %   |
|   V2    |            reset_info_capture             | rstmgr_reset                      |      7.000s       |    1213.694us    |    50     |   50    |  100.00 %   |
|   V2    |                stress_all                 | rstmgr_stress_all                 |      45.000s      |   11561.703us    |    50     |   50    |  100.00 %   |
|   V2    |                alert_test                 | rstmgr_alert_test                 |      2.000s       |     50.306us     |    50     |   50    |  100.00 %   |
|   V2    |           tl_d_oob_addr_access            | rstmgr_tl_errors                  |      3.000s       |    220.485us     |    20     |   20    |  100.00 %   |
|   V2    |            tl_d_illegal_access            | rstmgr_tl_errors                  |      3.000s       |    220.485us     |    20     |   20    |  100.00 %   |
|   V2    |          tl_d_outstanding_access          | rstmgr_csr_hw_reset               |      2.000s       |    111.996us     |     5     |    5    |  100.00 %   |
|   V2    |          tl_d_outstanding_access          | rstmgr_csr_rw                     |      2.000s       |     57.904us     |    20     |   20    |  100.00 %   |
|   V2    |          tl_d_outstanding_access          | rstmgr_csr_aliasing               |      2.000s       |    141.699us     |     5     |    5    |  100.00 %   |
|   V2    |          tl_d_outstanding_access          | rstmgr_same_csr_outstanding       |      3.000s       |    109.090us     |    20     |   20    |  100.00 %   |
|   V2    |            tl_d_partial_access            | rstmgr_csr_hw_reset               |      2.000s       |    111.996us     |     5     |    5    |  100.00 %   |
|   V2    |            tl_d_partial_access            | rstmgr_csr_rw                     |      2.000s       |     57.904us     |    20     |   20    |  100.00 %   |
|   V2    |            tl_d_partial_access            | rstmgr_csr_aliasing               |      2.000s       |    141.699us     |     5     |    5    |  100.00 %   |
|   V2    |            tl_d_partial_access            | rstmgr_same_csr_outstanding       |      3.000s       |    109.090us     |    20     |   20    |  100.00 %   |
|   V2    |                                           | **TOTAL**                         |                   |                  |    370    |   370   |  100.00 %   |
|   V2S   |                tl_intg_err                | rstmgr_sec_cm                     |      9.000s       |    4812.555us    |     5     |    5    |  100.00 %   |
|   V2S   |                tl_intg_err                | rstmgr_tl_intg_err                |      3.000s       |    1004.412us    |    20     |   20    |  100.00 %   |
|   V2S   |             prim_count_check              | rstmgr_sec_cm                     |      9.000s       |    4812.555us    |     5     |    5    |  100.00 %   |
|   V2S   |              prim_fsm_check               | rstmgr_sec_cm                     |      9.000s       |    4812.555us    |     5     |    5    |  100.00 %   |
|   V2S   |           sec_cm_bus_integrity            | rstmgr_tl_intg_err                |      3.000s       |    1004.412us    |    20     |   20    |  100.00 %   |
|   V2S   |         sec_cm_scan_intersig_mubi         | rstmgr_sec_cm_scan_intersig_mubi  |      3.000s       |     78.230us     |    50     |   50    |  100.00 %   |
|   V2S   |         sec_cm_leaf_rst_bkgn_chk          | rstmgr_leaf_rst_cnsty             |      4.000s       |    492.027us     |    24     |   50    |   48.00 %   |
|   V2S   |          sec_cm_leaf_rst_shadow           | rstmgr_leaf_rst_shadow_attack     |      2.000s       |     70.779us     |    50     |   50    |  100.00 %   |
|   V2S   |          sec_cm_leaf_fsm_sparse           | rstmgr_sec_cm                     |      9.000s       |    4812.555us    |     5     |    5    |  100.00 %   |
|   V2S   |        sec_cm_sw_rst_config_regwen        | rstmgr_csr_rw                     |      2.000s       |     57.904us     |    20     |   20    |  100.00 %   |
|   V2S   |      sec_cm_dump_ctrl_config_regwen       | rstmgr_csr_rw                     |      2.000s       |     57.904us     |    20     |   20    |  100.00 %   |
|   V2S   |                                           | **TOTAL**                         |                   |                  |    169    |   195   |   86.67 %   |
|         |                                           | **TOTAL**                         |                   |                  |    594    |   620   |   95.81 %   |

## Coverage Results
### [Coverage Dashboard](/home/kkoblasz/projects/mocha/scratch/kk_rst_mgr_dv/rstmgr.sim.xcelium/cov_report/index.html)

|  TOTAL  |  BLOCK  |  LINE/STATEMENT  |  BRANCH  |  TOGGLE  |   FSM   |  ASSERTION  |  FUNCTIONAL  |
|:-------:|:-------:|:----------------:|:--------:|:--------:|:-------:|:-----------:|:------------:|
| 94.58 % | 94.78 % |     94.67 %      | 90.47 %  | 96.99 %  | 72.11 % |   97.21 %   |   97.96 %    |

## Failure Buckets
* `UVM_FATAL (rstmgr_leaf_rst_cnsty_vseq.sv:159) [rstmgr_leaf_rst_cnsty_vseq] Timeout waiting for alert fatal_cnsty_fault` has 26 failures:
    * Test rstmgr_leaf_rst_cnsty has 26 failures.
        * 0.rstmgr_leaf_rst_cnsty.3893774066561404286679873924707946454294933251846102894542716694214554564731\
          Line 105, in log /home/kkoblasz/projects/mocha/scratch/kk_rst_mgr_dv/rstmgr.sim.xcelium/0.rstmgr_leaf_rst_cnsty/latest/run.log

                UVM_INFO @ 149854063 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                
                

        * 2.rstmgr_leaf_rst_cnsty.112716547968608135960797656090285886938387398042950550123403654793875186327527\
          Line 107, in log /home/kkoblasz/projects/mocha/scratch/kk_rst_mgr_dv/rstmgr.sim.xcelium/2.rstmgr_leaf_rst_cnsty/latest/run.log

                UVM_INFO @ 149876627 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                
                

        * ... and 24 more failures.


          [   legend    ]: [S: scheduled, Q: queued, R: running, P: passed, F: failed, K: killed, T: total]                                                                                          
00:01:14  [    build    ]: [S:       000, Q:    000, R:     000, P:    002, F:    000, K:    000, T:   002] 100%                                                                                     
00:02:38  [     run     ]: [S:       000, Q:    000, R:     000, P:    594, F:    026, K:    000, T:   620] 100%                                                                                     
00:03:12  [  cov_merge  ]: [S:       000, Q:    000, R:     000, P:    001, F:    000, K:    000, T:   001] 100%                                                                                     
00:03:19  [ cov_report  ]: [S:       000, Q:    000, R:     000, P:    001, F:    000, K:    000, T:   001] 100%       

Top level tests:
**dvsim hw/top_chip/dv/mocha_sim_cfgs.hjson --select-cfgs rstmgr -i smoke --cov**

### Test Results

|  Stage  |                   Name                    | Tests               |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:-----------------------------------------:|:--------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V1    |                   smoke                   | rstmgr_smoke        |      1.000s       |     76.585us     |     1     |    1    |  100.00 %   |
|   V1    |               csr_hw_reset                | rstmgr_csr_hw_reset |      2.000s       |    102.736us     |     1     |    1    |  100.00 %   |
|   V1    |                  csr_rw                   | rstmgr_csr_rw       |      1.000s       |     57.474us     |     1     |    1    |  100.00 %   |
|   V1    | regwen_csr_and_corresponding_lockable_csr | rstmgr_csr_rw       |      1.000s       |     57.474us     |     1     |    1    |  100.00 %   |
|   V1    |                                           | **TOTAL**           |                   |                  |     3     |    3    |  100.00 %   |
|   V2    |          tl_d_outstanding_access          | rstmgr_csr_hw_reset |      2.000s       |    102.736us     |     1     |    1    |  100.00 %   |
|   V2    |          tl_d_outstanding_access          | rstmgr_csr_rw       |      1.000s       |     57.474us     |     1     |    1    |  100.00 %   |
|   V2    |            tl_d_partial_access            | rstmgr_csr_hw_reset |      2.000s       |    102.736us     |     1     |    1    |  100.00 %   |
|   V2    |            tl_d_partial_access            | rstmgr_csr_rw       |      1.000s       |     57.474us     |     1     |    1    |  100.00 %   |
|   V2    |                                           | **TOTAL**           |                   |                  |     2     |    2    |  100.00 %   |
|   V2S   |        sec_cm_sw_rst_config_regwen        | rstmgr_csr_rw       |      1.000s       |     57.474us     |     1     |    1    |  100.00 %   |
|   V2S   |      sec_cm_dump_ctrl_config_regwen       | rstmgr_csr_rw       |      1.000s       |     57.474us     |     1     |    1    |  100.00 %   |
|   V2S   |                                           | **TOTAL**           |                   |                  |     1     |    1    |  100.00 %   |
|         |                                           | **TOTAL**           |                   |                  |     3     |    3    |  100.00 %   |

## Coverage Results
### [Coverage Dashboard](/home/kkoblasz/projects/mocha/scratch/kk_rst_mgr_dv/rstmgr.sim.xcelium/cov_report/index.html)

|  TOTAL  |  BLOCK  |  LINE/STATEMENT  |  BRANCH  |  TOGGLE  |   FSM   |  ASSERTION  |  FUNCTIONAL  |
|:-------:|:-------:|:----------------:|:--------:|:--------:|:-------:|:-----------:|:------------:|
| 70.37 % | 86.08 % |     85.15 %      | 74.59 %  | 92.83 %  | 17.69 % |   90.82 %   |   52.72 %    |


## TOP_MOCHA_BATCH_SIM Simulation Results (Summary)
### Tuesday May 26 2026 08:04:01 UTC
### Github Revision: [`351f095`](https://github.com/KolosKoblasz-Semify/mocha/tree/351f095f101db34028ecd074e8025d3948c59356)
### Branch: kk_rst_mgr_dv

|                        Name                         |  Passing  |  Total  |  Pass Rate  |  Coverage  |
|:---------------------------------------------------:|:---------:|:-------:|:-----------:|:----------:|
| [RSTMGR](scratch/kk_rst_mgr_dv/reports/rstmgr.html) |     3     |    3    |  100.00 %   |  70.37 %   |


          [   legend    ]: [S: scheduled, Q: queued, R: running, P: passed, F: failed, K: killed, T: total]                                                                                          
00:00:06  [    build    ]: [S:         0, Q:      0, R:       0, P:      2, F:      0, K:      0, T:     2] 100%                                                                                     
00:00:08  [     run     ]: [S:         0, Q:      0, R:       0, P:      3, F:      0, K:      0, T:     3] 100%                                                                                     
00:00:11  [  cov_merge  ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%                                                                                     
00:00:16  [ cov_report  ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%   
