### PR TITLE
[fpga] Remove duplicate system clock constraint

### DIFF
--- a/hw/top_chip/data/timing_genesys2.xdc
+++ b/hw/top_chip/data/timing_genesys2.xdc
@@ -3,7 +3,8 @@
 ## SPDX-License-Identifier: Apache-2.0
 
 ## System Clock Signal
-create_clock -period 5.000 -waveform {0 2.5} -name sys_clk_pin -add [get_ports sysclk_200m_pi];
+## Removed since the generated MIG already provides this clock constraint
+## create_clock -period 5.000 -waveform {0 2.5} -name sys_clk_pin -add [get_ports sysclk_200m_pi];
 
 ## Free-running Oscillator Clock from Configuration Logic
 create_clock -period 10.000 -waveform {0 5} -name cfg_clk_pin -add [get_pins clk_gen/STARTUPE2_inst/CFGMCLK];


### PR DESCRIPTION
The 200 MHz system clock constraint in `timing_genesys2.xdc` is a duplicate of the clock constraint provided by the MIG. This PR removes the duplicate constraint and avoids having 2 replicas of every clock appear when creating timing reports in Vivado.

Closes #516 