### PR TITLE
[nix] Bump Cheri-LLVM to 19.1.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1773161454,
-        "narHash": "sha256-cMX9fq3aPEQj8fixPAE/ZSiqM1DGHiFL0rrC7KskCRA=",
+        "lastModified": 1778066499,
+        "narHash": "sha256-EzZhINb99tgy6coGLvfWf4WFYj2Ocv/3gOvPm+zF5X0=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "bc3cf2d522e110393a432737da88f329acb634b7",
+        "rev": "dbdb63a2f4048181dd8ae77406fbb6637cf1d3fb",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770770419,
-        "narHash": "sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c5e707c6b5339359a9a9e215c5e66d6d802fd7a",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {

--- a/sw/device/lib/hal/mocha_irq.h
+++ b/sw/device/lib/hal/mocha_irq.h
@@ -10,6 +10,7 @@
 
 /* device IRQs at the PLIC */
 enum [[clang::flag_enum]] mocha_system_irq : uint32_t {
+    mocha_system_irq_none = (0),
     mocha_system_irq_invalid = (1u << 0),
     mocha_system_irq_unmapped_1 = (1u << 1),
     mocha_system_irq_unmapped_2 = (1u << 2),

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -201,7 +201,7 @@ static size_t format_capability(char *buf, const uintptr_t value)
     buf[total++] = '[';
 
     /* capability permissions to check */
-    cheri_perms_t perms[7] = {
+    size_t perms[7] = {
         CHERI_PERM_READ,
         CHERI_PERM_WRITE,
         CHERI_PERM_EXECUTE,


### PR DESCRIPTION
```sh
❯ clang --version
clang version 19.1.7
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /nix/store/wcbx51xi28jh58s6rdzbxqcgxb200h0k-llvm-cheri-19.1.7/bin
Build config: +assertions
```

Fix https://github.com/lowRISC/mocha/issues/273