### PR TITLE
Enable SW optimzation O1

### DIFF
--- a/sw/cheri_toolchain.cmake
+++ b/sw/cheri_toolchain.cmake
@@ -32,14 +32,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(LDS_DIR "${CMAKE_SOURCE_DIR}/device/lib/boot")
 
 string(CONCAT CMAKE_CXX_FLAGS_INIT
-  "-std=c++20 -O0 -g"
+  "-std=c++20 -O1 -g"
   " -ffreestanding -static"
   " -fno-builtin -fno-exceptions -fno-c++-static-destructors -fno-rtti"
   " -Wall -Wextra"
 )
 
 string(CONCAT CMAKE_C_FLAGS_INIT
-  "-std=c99 -O0 -g"
+  "-std=c99 -O1 -g"
   " -ffreestanding -static"
   " -fno-builtin"
   " -Wall -Wextra"

--- a/sw/device/lib/hal/spi_host.c
+++ b/sw/device/lib/hal/spi_host.c
@@ -25,3 +25,14 @@ uint32_t spi_host_read(spi_host_t spi_host)
 {
     return DEV_READ(spi_host + SPI_HOST_RXDATA_REG);
 }
+
+uint32_t spi_host_status(spi_host_t spi_host)
+{
+    return DEV_READ(spi_host + SPI_HOST_STATUS_REG);
+}
+
+void spi_host_wait_for_idle(spi_host_t spi_host)
+{
+    while ((spi_host_status(spi_host) & SPI_HOST_STATUS_ACTIVE_MASK) != 0) {
+    };
+}

--- a/sw/device/lib/hal/spi_host.h
+++ b/sw/device/lib/hal/spi_host.h
@@ -15,6 +15,7 @@
 #define SPI_HOST_CONTROL_SPIEN_MASK              (1u << 31)
 #define SPI_HOST_CONTROL_OUTPUTEN_MASK           (1u << 29)
 #define SPI_HOST_STATUS_REG                      (0x14)
+#define SPI_HOST_STATUS_ACTIVE_MASK              (1u << 30)
 #define SPI_HOST_CONFIGOPTS_REG                  (0x18)
 #define SPI_HOST_CSID_REG                        (0x1C)
 #define SPI_HOST_COMMAND_REG                     (0x20)
@@ -32,3 +33,5 @@ typedef void *spi_host_t;
 void spi_host_init(spi_host_t spi_host);
 void spi_host_write(spi_host_t spi_host, uint32_t data);
 uint32_t spi_host_read(spi_host_t spi_host);
+uint32_t spi_host_status(spi_host_t spi_host);
+void spi_host_wait_for_idle(spi_host_t spi_host);

--- a/sw/device/lib/hal/uart.c
+++ b/sw/device/lib/hal/uart.c
@@ -60,6 +60,16 @@ bool uart_interrupt_any_pending(uart_t uart, uart_intr intrs)
     return (VOLATILE_READ(uart->intr_state) & intrs) != 0u;
 }
 
+bool uart_status_any(uart_t uart, uart_status status)
+{
+    return (VOLATILE_READ(uart->status) & status) != 0u;
+}
+
+bool uart_status_all(uart_t uart, uart_status status)
+{
+    return (VOLATILE_READ(uart->status) & status) == status;
+}
+
 void uart_loopback_set(uart_t uart, bool system_enable, bool line_enable)
 {
     uart_ctrl ctrl = VOLATILE_READ(uart->ctrl);

--- a/sw/device/lib/hal/uart.h
+++ b/sw/device/lib/hal/uart.h
@@ -22,6 +22,14 @@ void uart_interrupt_force(uart_t uart, uart_intr intrs);
 void uart_interrupt_clear(uart_t uart, uart_intr intrs);
 bool uart_interrupt_all_pending(uart_t uart, uart_intr intrs);
 bool uart_interrupt_any_pending(uart_t uart, uart_intr intrs);
+bool uart_status_any(uart_t uart, uart_status status);
+bool uart_status_all(uart_t uart, uart_status status);
+
+static inline void uart_wait_for(uart_t uart, uart_status status)
+{
+    while (!uart_status_any(uart, status)) {
+    };
+}
 
 void uart_loopback_set(uart_t uart, bool system_enable, bool line_enable);
 char uart_in(uart_t uart);

--- a/sw/device/lib/test_framework/main.c
+++ b/sw/device/lib/test_framework/main.c
@@ -78,9 +78,13 @@ test_exception_handler(struct trap_registers *registers, struct trap_context *co
     void *dv_test_status = mocha_system_dv_test_status();
 
     uart_init(console);
+    // Flush the uart
+    uart_wait_for(console, uart_status_txidle);
     DEV_WRITE(dv_test_status, TEST_STATUS_IN_TEST);
 
     bool result = test_main(console);
+    // Flush the uart
+    uart_wait_for(console, uart_status_txidle);
 
     test_exit(result);
 }

--- a/sw/device/tests/axi_sram/smoketest.c
+++ b/sw/device/tests/axi_sram/smoketest.c
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool rapid_write_test()
+static bool rapid_write_test()
 {
     uint64_t d1 = 0xB03747F359ABBCFEUL, res1;
     uint64_t d2 = 0x0A197F0071E028A1UL, res2;

--- a/sw/device/tests/spi_host/smoketest.c
+++ b/sw/device/tests/spi_host/smoketest.c
@@ -16,6 +16,7 @@ bool test_main()
     spi_host = mocha_system_spi_host();
     spi_host_init(spi_host);
     spi_host_write(spi_host, tx_data);
+    spi_host_wait_for_idle(spi_host);
     rx_data = spi_host_read(spi_host);
     return tx_data == rx_data;
 }

--- a/sw/device/tests/uart/smoketest.c
+++ b/sw/device/tests/uart/smoketest.c
@@ -3,26 +3,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "hal/uart.h"
+#include "runtime/print.h"
 #include <stdbool.h>
 #include <stdint.h>
 
-const char uart_loopback_test_string[] = "Test String";
+const static char uart_loopback_test_string[] = "Test String";
 
 static bool loopback_test(uart_t uart)
 {
+    // Flush the uart
+    uart_wait_for(uart, uart_status_txidle);
+
     uart_loopback_set(uart, true, true);
     for (uint32_t idx = 0; idx < sizeof(uart_loopback_test_string); idx++) {
         uart_out(uart, uart_loopback_test_string[idx]);
     }
+    // Wait for the transmission to finish
+    uart_wait_for(uart, uart_status_txidle);
+    uart_loopback_set(uart, false, false);
 
     bool res = true;
     for (uint32_t idx = 0; idx < sizeof(uart_loopback_test_string); idx++) {
-        if (uart_in(uart) != uart_loopback_test_string[idx]) {
+        while (uart_status_any(uart, uart_status_rxempty)) {
+        };
+        char rx = uart_in(uart);
+        if (rx != uart_loopback_test_string[idx]) {
+            uprintf(uart, "Expected: %c, got: %c\n", rx, uart_loopback_test_string[idx]);
             res = false;
             break;
         }
     }
-    uart_loopback_set(uart, false, false);
     return res;
 }
 


### PR DESCRIPTION
I also resolved some tests that failed due to timing issues triggered by the optimization.
Opensbi load before:
 ```md
      Start  2: opensbi_with_opensbi_test_payload_fpga_genesys2
 1/37 Test  #2: opensbi_with_opensbi_test_payload_fpga_genesys2 .......   Passed   31.02 sec
 ```
 After:
```md
      Start  2: opensbi_with_opensbi_test_payload_fpga_genesys2
 1/37 Test  #2: opensbi_with_opensbi_test_payload_fpga_genesys2 .......   Passed   25.27 sec
 ```
fix https://github.com/lowRISC/mocha/issues/550