### PR TITLE
[ftditool] Bump to version v0.3.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,16 +49,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776265235,
-        "narHash": "sha256-plScTho+ceeQCSwzN1q+gwwS3Oiu58Z+pQ1fSSuw+Zk=",
+        "lastModified": 1779108040,
+        "narHash": "sha256-8xyx4xPeNEfNDPeh7NJYl5l7h8XD9X6xxrYSd35AnQo=",
         "owner": "lowRISC",
         "repo": "ftditool",
-        "rev": "1d7a587e0ca21ca3a09811ded78b07bd72ed07c1",
+        "rev": "27173d45ef42172ecb683197f25f5d438e620f59",
         "type": "github"
       },
       "original": {
         "owner": "lowRISC",
-        "ref": "v0.2.0",
+        "ref": "v0.3.0",
         "repo": "ftditool",
         "type": "github"
       }
@@ -88,11 +88,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1778066499,
-        "narHash": "sha256-EzZhINb99tgy6coGLvfWf4WFYj2Ocv/3gOvPm+zF5X0=",
+        "lastModified": 1778839577,
+        "narHash": "sha256-KtbcYK/X9MuJXvhHIjyd65j/QGWPFpHJr/yTy8W7xg8=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "dbdb63a2f4048181dd8ae77406fbb6637cf1d3fb",
+        "rev": "d3ef4932bf95666853cb879468c4228ddc8104e6",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773630502,
-        "narHash": "sha256-DGwOOdxYPlPxnGJ+Vsyd81f4sviczbez0i33KAzQT5Q=",
+        "lastModified": 1776659114,
+        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "749899cbaea96b295acaf54e406d237545ede329",
+        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773553880,
-        "narHash": "sha256-wfvYZMO2NOGBw/DiYX50FFvr2pIS/hjJ9Bx0FD3LH5E=",
+        "lastModified": 1778901413,
+        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "3799d59a6886bed706eed9d209d7fc9db8ae9040",
+        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773713054,
-        "narHash": "sha256-5CzBhBYp66hIPj9Ju0yJEKdc8pzlk2/Gs7/ZC3tzNQ4=",
+        "lastModified": 1778664018,
+        "narHash": "sha256-ogNyNANNLo0SMFevIeUpbTMOL9uUDu/hXvp7JlOYbwQ=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "4f155975dee6e52775800959e68154777f3ed694",
+        "rev": "b48abe99ef639cd100c224898529370e5d935294",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       inputs.uv2nix.follows = "uv2nix";
     };
     ftditool = {
-      url = "github:lowRISC/ftditool?ref=v0.2.0";
+      url = "github:lowRISC/ftditool?ref=v0.3.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -95,6 +95,7 @@ async def load_fpga_test(test: Path, uart) -> None:
         "bootstrap",
         "--addr",
         hex(get_load_addr(test)),
+        "--skip-erase",
         "--ftdi",
         FTDI_DEVICE_DESC,
     ]


### PR DESCRIPTION
This version improves the spi bootstrap command throughput by a factor of 2x.
CI before the update:
```sh
Test project /home/runner/_work/mocha/mocha/build/sw
      Start  2: opensbi_with_opensbi_test_payload_fpga_genesys2
 1/41 Test  #2: opensbi_with_opensbi_test_payload_fpga_genesys2 .......   Passed   32.83 sec
 ```
 after:
```sh
Test project /home/runner/_work/mocha/mocha/build/sw
      Start  2: opensbi_with_opensbi_test_payload_fpga_genesys2
 1/41 Test  #2: opensbi_with_opensbi_test_payload_fpga_genesys2 .......   Passed   21.07 sec
```
Fix https://github.com/lowRISC/mocha/issues/562