### PR TITLE
[sw,dv] Fix SPI device SyncReqAckDataHoldSrc2Dst assertion failure

### DIFF
--- a/sw/device/lib/hal/spi_device.c
+++ b/sw/device/lib/hal/spi_device.c
@@ -56,7 +56,12 @@ void spi_device_enable_set(spi_device_t spi_device, bool enable)
     DEV_WRITE(spi_device + SPI_DEVICE_CTRL_REG, enable << SPI_DEVICE_CTRL_MODE_OFFSET);
 }
 
-void spi_device_4b_addr_mode_enable_set(spi_device_t spi_device, bool enable)
+void spi_device_4b_addr_mode_enable_set_non_blocking(spi_device_t spi_device, bool enable)
+{
+    DEV_WRITE(spi_device + SPI_DEVICE_ADDR_MODE_REG, (uint32_t)enable);
+}
+
+void spi_device_4b_addr_mode_enable_set_blocking(spi_device_t spi_device, bool enable)
 {
     DEV_WRITE(spi_device + SPI_DEVICE_ADDR_MODE_REG, (uint32_t)enable);
 
@@ -574,7 +579,7 @@ void spi_device_sfdp_table_init(spi_device_t spi_device)
 
 void spi_device_init(spi_device_t spi_device)
 {
-    spi_device_4b_addr_mode_enable_set(spi_device, true);
+    spi_device_4b_addr_mode_enable_set_non_blocking(spi_device, true);
     spi_device_jedec_cc_set(spi_device, MOCHA_SPI_DEVICE_JEDEC_CC, MOCHA_SPI_DEVICE_JEDEC_CC_COUNT);
     spi_device_jedec_id_set(spi_device, MOCHA_SPI_DEVICE_ROM_BOOTSTRAP, MOCHA_SPI_DEVICE_CHIP_REV,
                             MOCHA_SPI_DEVICE_CHIP_GEN, MOCHA_SPI_DEVICE_DENSITY_BYTES_LOG2,

--- a/sw/device/lib/hal/spi_device.h
+++ b/sw/device/lib/hal/spi_device.h
@@ -27,7 +27,7 @@
 
 #define SPI_DEVICE_ADDR_MODE_REG          (0x20)
 #define SPI_DEVICE_ADDR_MODE_4B_EN_MASK   (0x1)
-#define SPI_DEVICE_ADDR_MODE_PENDING_MASK (0x70000000)
+#define SPI_DEVICE_ADDR_MODE_PENDING_MASK (0x80000000)
 
 #define SPI_DEVICE_FLASH_STATUS_REG       (0x28)
 #define SPI_DEVICE_FLASH_STATUS_BUSY_MASK (0x1)
@@ -177,7 +177,8 @@ void spi_device_interrupt_enable(spi_device_t spi_device, uint8_t intr_id);
 void spi_device_interrupt_disable(spi_device_t spi_device, uint8_t intr_id);
 void spi_device_interrupt_trigger(spi_device_t spi_device, uint8_t intr_id);
 void spi_device_enable_set(spi_device_t spi_device, bool enable);
-void spi_device_4b_addr_mode_enable_set(spi_device_t spi_device, bool enable);
+void spi_device_4b_addr_mode_enable_set_non_blocking(spi_device_t spi_device, bool enable);
+void spi_device_4b_addr_mode_enable_set_blocking(spi_device_t spi_device, bool enable);
 bool spi_device_4b_addr_mode_enable_get(spi_device_t spi_device);
 void spi_device_flash_status_set(spi_device_t spi_device, uint32_t flash_status);
 uint32_t spi_device_flash_status_get(spi_device_t spi_device);

--- a/sw/device/tests/spi_device/smoketest.c
+++ b/sw/device/tests/spi_device/smoketest.c
@@ -48,16 +48,6 @@ bool cmd_info_readback_test(spi_device_t spi_device, uint32_t offset)
 
 bool reg_test(spi_device_t spi_device)
 {
-    spi_device_4b_addr_mode_enable_set(spi_device, true);
-    if (!spi_device_4b_addr_mode_enable_get(spi_device)) {
-        return false;
-    }
-
-    spi_device_4b_addr_mode_enable_set(spi_device, false);
-    if (spi_device_4b_addr_mode_enable_get(spi_device)) {
-        return false;
-    }
-
     spi_device_jedec_cc_set(spi_device, 0xE1, 0x45);
     if ((spi_device_jedec_cc_get(spi_device) & 0xFFFF) != 0x45E1) {
         return false;


### PR DESCRIPTION
This PR fixes the `SyncReqAckDataHoldSrc2Dst` assertion error in UVM.

The address mode pending mask in the SPI device driver is corrected and the smoke test is updated to not change the address mode multiple times.

Closes #145