### PR TITLE
[rtl,sw] Fix tag cache eviction write logic

### DIFF
--- a/hw/ip/common_cells/rtl/counter.sv
+++ b/hw/ip/common_cells/rtl/counter.sv
@@ -33,6 +33,13 @@ module counter #(
     .commit_i           (1'b1),
     .cnt_o              (q_o),
     .cnt_after_commit_o ( ),
-    .err_o              (overflow_o)
+    .err_o              ( )
   );
+
+  // Generate sticky overflow flag as prim_count is a saturating counter
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if      (!rst_ni)             overflow_o <= 1'b0;
+    else if (clear_i || load_i)   overflow_o <= 1'b0;
+    else if (!overflow_o && en_i) overflow_o <= (q_o == '1 && !down_i) || (q_o == '0 && down_i);
+  end
 endmodule

--- a/hw/vendor/patches/pulp_axi_llc/0001_Initial_Compilation_Fixes.patch
+++ b/hw/vendor/patches/pulp_axi_llc/0001_Initial_Compilation_Fixes.patch
@@ -359,28 +359,6 @@ index c217401..4b50741 100644
    typedef logic [SelIdxWidth-1:0]          way_sel_t; // Binary representation of the way selection
    typedef logic [Cfg.SetAssociativity-1:0] way_ind_t; // way indicator for switching decision
  
-diff --git a/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv b/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
-index 2d9b2f8..130372e 100644
---- a/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
-+++ b/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
-@@ -224,9 +224,16 @@ module axi_llc_tag_pattern_gen #(
-     .down_i    (     down_cnt ),
-     .d_i       (     data_cnt ),
-     .q_o       (      index_o ),
--    .overflow_o( overflow_cnt )
-+    .overflow_o( )
-   );
- 
-+  // Generate sticky overflow flag as prim_count is a saturating counter
-+  always_ff @(posedge clk_i or negedge rst_ni) begin
-+    if      (!rst_ni)                 overflow_cnt <= 1'b0;
-+    else if (clear_cnt || load_cnt)   overflow_cnt <= 1'b0;
-+    else if (!overflow_cnt && en_cnt) overflow_cnt <= (index_o == '1 && !down_cnt) || (index_o == '0 && down_cnt);
-+  end
-+
-   // Flip Flops
-   `FFLARN(busy_q,     busy_d,     switch_busy,      '0, clk_i, rst_ni)
-   `FFLARN(eoc_q,      eoc_d,      '1,               '0, clk_i, rst_ni)
 diff --git a/src/hit_miss_detect/axi_llc_tag_store.sv b/src/hit_miss_detect/axi_llc_tag_store.sv
 index d15691a..b9c922b 100644
 --- a/src/hit_miss_detect/axi_llc_tag_store.sv

--- a/hw/vendor/pulp_axi_llc/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
+++ b/hw/vendor/pulp_axi_llc/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
@@ -224,15 +224,8 @@ module axi_llc_tag_pattern_gen #(
     .down_i    (     down_cnt ),
     .d_i       (     data_cnt ),
     .q_o       (      index_o ),
-    .overflow_o( )
+    .overflow_o( overflow_cnt )
   );
-
-  // Generate sticky overflow flag as prim_count is a saturating counter
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if      (!rst_ni)                 overflow_cnt <= 1'b0;
-    else if (clear_cnt || load_cnt)   overflow_cnt <= 1'b0;
-    else if (!overflow_cnt && en_cnt) overflow_cnt <= (index_o == '1 && !down_cnt) || (index_o == '0 && down_cnt);
-  end
 
   // Flip Flops
   `FFLARN(busy_q,     busy_d,     switch_busy,      '0, clk_i, rst_ni)

--- a/sw/device/tests/tag_controller/tag_test.c
+++ b/sw/device/tests/tag_controller/tag_test.c
@@ -7,6 +7,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+enum {
+    evict_test_capabilities = 32u,
+};
+
 bool tag_test()
 {
 #if defined(__riscv_zcherihybrid)
@@ -15,7 +19,7 @@ bool tag_test()
     uint64_t res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12, res13,
         res14, res15;
 
-    __asm__ volatile(
+    asm volatile(
         // Get capability to dram in ct0.
         "auipc ct0, 0\n\t"
         "scaddr ct0, ct0, %15\n\t"
@@ -97,7 +101,7 @@ bool tag_test()
         return false;
     }
 
-    __asm__ volatile(
+    asm volatile(
         // Get capability to dram in ct0.
         "auipc ct0, 0\n\t"
         "scaddr ct0, ct0, %6\n\t"
@@ -136,7 +140,7 @@ bool tag_test()
         return false;
     }
 
-    __asm__ volatile(
+    asm volatile(
         // Get capability to dram in ct0.
         "auipc ct0, 0\n\t"
         "scaddr ct0, ct0, %6\n\t"
@@ -179,7 +183,93 @@ bool tag_test()
     return true;
 }
 
+#if defined(__riscv_zcherihybrid)
+void write_valid_cap(const uint64_t addr)
+{
+    asm volatile(
+        // Get capability to address.
+        "auipc ct0, 0\n\t"
+        "scaddr ct0, ct0, %0\n\t"
+
+        // Store valid capability.
+        "csc ct0, 0(ct0)\n\t"
+        "fence\n\t"
+        :
+        : "r"(addr)
+        : "ct0", "memory");
+}
+
+void write_invalid_cap(const uint64_t addr)
+{
+    asm volatile(
+        // Get capability to address.
+        "auipc ct0, 0\n\t"
+        "scaddr ct0, ct0, %0\n\t"
+
+        // Store invalid capability.
+        "csc cnull, 0(ct0)\n\t"
+        "fence\n\t"
+        :
+        : "r"(addr)
+        : "ct0", "memory");
+}
+
+bool cap_is_valid(const uint64_t addr)
+{
+    uint64_t res;
+
+    asm volatile(
+        // Get capability to address.
+        "auipc ct0, 0\n\t"
+        "scaddr ct0, ct0, %1\n\t"
+
+        // Check if tag is set.
+        "clc ct1, 0(ct0)\n\t"
+        "gctag %0, ct1\n\t"
+        : "=r"(res)
+        : "r"(addr)
+        : "ct0", "ct1");
+
+    return res != 0;
+}
+#endif /* defined(__riscv_zcherihybrid) */
+
+bool tag_cache_evict_test()
+{
+#if defined(__riscv_zcherihybrid)
+    for (int i = 0; i < evict_test_capabilities; ++i) {
+        write_valid_cap(0x81000000UL + (i << 24));
+    }
+
+    for (int i = 0; i < evict_test_capabilities; ++i) {
+        if (!cap_is_valid(0x81000000UL + (i << 24))) {
+            return false;
+        }
+    }
+
+    for (int i = 0; i < evict_test_capabilities; ++i) {
+        if ((i & 1) == 1) {
+            write_invalid_cap(0x81000000UL + (i << 24));
+        }
+    }
+
+    for (int i = 0; i < evict_test_capabilities; ++i) {
+        if ((i & 1) == 0) {
+            if (!cap_is_valid(0x81000000UL + (i << 24))) {
+                return false;
+            }
+        } else {
+            if (cap_is_valid(0x81000000UL + (i << 24))) {
+                return false;
+            }
+        }
+    }
+#endif /* defined(__riscv_zcherihybrid) */
+
+    return true;
+}
+
 bool test_main()
 {
-    return tag_test();
+    return tag_test() && tag_cache_evict_test();
 }


### PR DESCRIPTION
This PR moves the overflow flag logic added in the AXI LLC to the common_cells counter. This fixes the tag cache eviction write bug which caused the OpenSBI tag fault.

The tag controller tag test is also updated to check evicted tags.

Closes #528.