### PR TITLE
[hw,dv,sw] Add support for HW_ID for SW

### DIFF
--- a/hw/top_chip/dv/README.md
+++ b/hw/top_chip/dv/README.md
@@ -57,14 +57,15 @@ Because simulating the CPU boot ROM process is slow, we load the software binary
 ## SW-to-DV Communication
 
 To facilitate interactions between the Software and the DV environment, we utilize the **`sim_sram_axi`** module.
-This is a special hardware block inserted only during simulation that intercepts AXI traffic.
 
 For more details, see: [sim_sram_axi/README.md](./sim_sram_axi/README.md)
 
 ### Mechanism
 
-1. **Interception:** The module "swallows" traffic destined for a specific Simulation Address Range (`SW_DV_START_ADDR`).
-   Traffic outside this range is transparently forwarded to the AXI Crossbar.
+1. **Dedicated crossbar port:** The SW-DV window (`0x2002_0000`, 256 bytes) is a first-class device on the main AXI crossbar inside `top_chip_system`.
+   The crossbar routes all accesses to this range out via the `sw_dv_req_o`/`sw_dv_resp_i` port pair, keeping it completely separate from the rest-of-chip bus.
+   In simulation, `tb.sv` connects `sim_sram_axi_sink` to this port as a plain AXI slave.
+   On FPGA, `chip_mocha_genesys2` connects the same port to its hardware ID logic.
 2. **Binding:** In `tb.sv`, we `bind` verification interfaces (`sw_test_status_if` and `sw_logger_if`) to this module.
 
 ### Use Cases

--- a/hw/top_chip/dv/env/top_chip_dv_env_pkg.sv
+++ b/hw/top_chip/dv/env/top_chip_dv_env_pkg.sv
@@ -41,11 +41,15 @@ package top_chip_dv_env_pkg;
   // 50 MHz Peripheral clock
   parameter int unsigned PeriClkFreq = 50_000_000;
 
-  // SW DV special write locations for test status and logging will always fit in 32-bits
+  // SW-DV special locations for test status, logging, and platform identification.
+  // In simulation, sim_sram_axi_sink is connected to the dedicated sw_dv crossbar port.
   parameter bit [31:0] SW_DV_START_ADDR       = 'h2002_0000;
   parameter bit [31:0] SW_DV_SIZE             = 'h0000_0100;        // 256 bytes reserved for SW DV
   parameter bit [31:0] SW_DV_TEST_STATUS_ADDR = SW_DV_START_ADDR + 'h00;
-  parameter bit [31:0] SW_DV_LOG_ADDR         = SW_DV_START_ADDR + 'h04;
+  parameter bit [31:0] SW_DV_HW_ID_ADDR       = SW_DV_START_ADDR + 'h04;
+  parameter bit [31:0] SW_DV_LOG_ADDR         = SW_DV_START_ADDR + 'h08;
+
+  parameter bit [31:0] SW_DV_HW_ID            = top_pkg::HwIdSimUvm;
 
   // File includes
   `include "mem_clear_util.sv"

--- a/hw/top_chip/dv/sim_sram_axi/README.md
+++ b/hw/top_chip/dv/sim_sram_axi/README.md
@@ -6,14 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 # Simulation SRAM AXI
 
-The `sim_sram_axi_sink` module intercepts an outbound AXI interface to carve out a chunk of "fake" memory used for simulation purposes only.
-This chunk of memory must not overlap with any device on the system address map - it must be an invalid address range from the system's perspective.
+The `sim_sram_axi_sink` module is a plain AXI subordinate that provides a chunk of "fake" memory used for simulation purposes only.
+It is attached to the `SwDvWindow` device port of the main AXI crossbar inside `top_chip_system` - a dedicated, first-class entry in the crossbar's address map - so it only ever sees traffic the crossbar has already routed to that range.
 
-It has 4 interfaces - clock, reset, input AXI interface from the CVA6 CPU (`cpu_req_i` and `cpu_resp_o`) and the output AXI interface to the AXI Crossbar (`xbar_req_o` and `xbar_resp_i`).
-It instantiates a [1:2 AXI Demultiplexer](../../../vendor/pulp_axi/doc/axi_demux.md) to split the incoming AXI access into two.
-One of the outputs of the socket is sinked within the module while the other is returned back.
+It has 3 interfaces - clock, reset, and a single AXI slave port (`axi_req_i` and `axi_resp_o`) fed exclusively by the crossbar's `SwDvWindow` device.
 
-If the user chooses to instantiate an actual SRAM instance (`InstantiateSram=1`), the sinked AXI interface is connected to the AXI to SRAM adapter `axi_to_mem` which converts the AXI access into a SRAM access.
+If the user chooses to instantiate an actual SRAM instance (`InstantiateSram=1`), the AXI interface is connected to the AXI to SRAM adapter `axi_to_mem` which converts the AXI access into a SRAM access.
 The [technology-independent](../../../ip/prim/README.md) `prim_ram_1p` module is used for instantiating the memory.
 
 ![Block Diagram](./doc/sim_sram_axi.svg)
@@ -31,8 +29,7 @@ In DV, this is envisioned to be used for the following purposes:
 These usecases apply to Verilator as well.
 However, at this time, the Verilator based simulations rely on the on-device UART for logging.
 
-This module must be instantiated before any XBAR / bus fabric element in the design which can return an error response when it sees an access to an invalid address range.
-Ideally, it should be placed as close to the CPU (or equivalent) as possible to reduce the simulation time.
+This module is attached as a subordinate device on the main AXI crossbar via the dedicated `SwDvWindow` port, so its position in the design is fixed by the crossbar's address map rather than by where it is instantiated.
 
 ## Customizations
 
@@ -76,22 +73,11 @@ In the Testbench Top (`tb.sv`), higher-level verification interfaces are `bind`-
 
 ## Usage
 
-This module needs to be instantiated on an existing outbound AXI connection, possibly deep in an existing design hierarchy while also abiding by these guidelines:
-- Design sources must not depend on simulation components.
-- Design sources must not directly instantiate simulation components, even with `ifdefs`.
-- Synthesis of the design must not disturbed whatsoever.
-- We must be able to run simulations with Verilator (which prevents us from using forces for example).
+`sim_sram_axi_sink` is instantiated purely in the testbench, never in synthesizable RTL, so design sources never depend on or instantiate simulation components.
 
-One way of achieving this is by disconnecting an outbound AXI interface in the design source where `sim_sram_axi_sink` needs to be inserted.
-The disconnection must be made in the desired design block ONLY if `` `SYNTHESIS`` is NOT defined and a special macro (user's choice on the name) is defined for simulations.
+Isolation from the design is achieved at the crossbar level rather than by cutting and forcing signals:
+- `top_pkg.sv` reserves `SwDvWindow` as a first-class device on the main AXI crossbar inside `top_chip_system`, with its own fixed base address and length.
+- `top_chip_system` exposes that device directly as a chip-level port pair, `sw_dv_req_o`/`sw_dv_resp_i`, alongside the other chip-level AXI ports (DRAM, rest-of-chip, etc).
+- Each testbench top (`tb.sv` for UVM/DV, `top_chip_verilator.sv` for Verilator) connects `sim_sram_axi_sink` to that port pair as a plain AXI subordinate.
 
-The sim_sram_axi_sink is always instantiated in the testbench.
-The connection method changes based on the simulation mode:
-
-- Verilator (`` `INST_SIM_SRAM`` is defined):
-The TB connects to the DUT's internal signals via hierarchical references (assign).
-Since the RTL connection was "cut" (see above), there is no contention, and force is not required.
-
-- UVM (`` `INST_SIM_SRAM`` is **NOT** defined):
-The RTL connection is intact.
-The TB uses force statements to override the internal wires at runtime, effectively inserting the sink without modifying the compiled RTL logic.
+Because the crossbar - not the sink - decides which traffic reaches this module, no `ifdefs`, forces, or synthesis-only disconnection tricks are needed, and the same connection method works identically for UVM and Verilator.

--- a/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_if.sv
+++ b/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_if.sv
@@ -15,6 +15,8 @@ interface sim_sram_axi_if (
   // Control signals set by the Testbench
   logic [31:0] start_addr;
   logic [31:0] sw_dv_size;
+  logic [31:0] hw_id_addr;
+  logic [31:0] hw_id;
 
   // Monitor signals driven by the Sink
   axi_req_t  req;

--- a/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_if.sv
+++ b/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_if.sv
@@ -19,8 +19,8 @@ interface sim_sram_axi_if (
   logic [31:0] hw_id;
 
   // Monitor signals driven by the Sink
-  axi_req_t  req;
-  axi_resp_t resp;
+  axi_dev_req_t  req;
+  axi_dev_resp_t resp;
 
   // Logic to qualify a valid "Simulation Write"
   logic wr_valid;

--- a/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_sink.sv
+++ b/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_sink.sv
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Block inserted between the CPU and the AXI-Crossbar, it intercepts the AXI traffic within the
-// simulation memory range to provide a dedicated channel for SW <-> DV communication. The AXI
-// traffic within the SW DV range falls into a "sink".
-// AXI traffic outside this range is transparently forwarded to the AXI Crossbar.
+// Plain AXI subordinate attached to the AXI crossbar's dedicated SwDvWindow device port. It
+// provides a dedicated channel for SW <-> DV communication: all traffic reaching this module has
+// already been routed here by the crossbar, so no address-range filtering happens in this block.
 module sim_sram_axi_sink #(
   parameter bit InstantiateSram = 1'b0, // 1: Instantiate the SRAM memory
   parameter int SramDepth       = 8,    // Depth of the SRAM in words
@@ -14,50 +13,13 @@ module sim_sram_axi_sink #(
   input logic clk_i,
   input logic rst_ni,
 
-  // Interface from CVA6 CPU
-  input  top_pkg::axi_req_t  cpu_req_i,
-  output top_pkg::axi_resp_t cpu_resp_o,
-
-  // Interface to AXI Crossbar
-  output top_pkg::axi_req_t  xbar_req_o,
-  input  top_pkg::axi_resp_t xbar_resp_i
+  // AXI slave port: receives only SW-DV window traffic from the crossbar
+  input  top_pkg::axi_dev_req_t  axi_req_i,
+  output top_pkg::axi_dev_resp_t axi_resp_o
 );
 
   import top_pkg::*;
   import cva6_config_pkg::*;
-
-  // Internal AXI signals for the intercepted path
-  axi_req_t  sim_req;
-  axi_resp_t sim_resp;
-
-  logic aw_select;
-  logic ar_select;
-
-  // Selection Logic
-  assign aw_select  = (cpu_req_i.aw.addr >= u_sim_sram_if.start_addr) &&
-                      (cpu_req_i.aw.addr < u_sim_sram_if.start_addr + u_sim_sram_if.sw_dv_size);
-  assign ar_select  = (cpu_req_i.ar.addr >= u_sim_sram_if.start_addr) &&
-                      (cpu_req_i.ar.addr < u_sim_sram_if.start_addr + u_sim_sram_if.sw_dv_size);
-
-  // AXI Demux: index 0 = System Bus, index 1 = Sim Sink
-  axi_demux_simple #(
-    .AxiIdWidth       (AxiIdWidth             ),
-    .AtopSupport      (1'b0                   ),
-    .axi_req_t        (axi_req_t              ),
-    .axi_resp_t       (axi_resp_t             ),
-    .NoMstPorts       (2                      ),
-    .MaxTrans         (8                      )
-  ) i_axi_demux (
-    .clk_i,
-    .rst_ni,
-    .test_i           (1'b0                   ),
-    .slv_req_i        (cpu_req_i              ),
-    .slv_aw_select_i  (aw_select              ),
-    .slv_ar_select_i  (ar_select              ),
-    .slv_resp_o       (cpu_resp_o             ),
-    .mst_reqs_o       ({sim_req,  xbar_req_o} ),
-    .mst_resps_i      ({sim_resp, xbar_resp_i})
-  );
 
   // AXI Protocol conversion to memory interface
   logic                             mem_req;
@@ -82,18 +44,18 @@ module sim_sram_axi_sink #(
   end
 
   axi_to_mem #(
-    .axi_req_t    (top_pkg::axi_req_t     ),
-    .axi_resp_t   (top_pkg::axi_resp_t    ),
+    .axi_req_t    (top_pkg::axi_dev_req_t ),
+    .axi_resp_t   (top_pkg::axi_dev_resp_t),
     .DataWidth    (top_pkg::AxiDataWidth  ),
     .AddrWidth    (top_pkg::AxiAddrWidth  ),
-    .IdWidth      (top_pkg::AxiIdWidth    ),
+    .IdWidth      (top_pkg::AxiDevIdWidth ),
     .NumBanks     (1                      )
   ) i_axi_to_mem (
     .clk_i        (clk_i        ),
     .rst_ni       (rst_ni       ),
     .busy_o       (             ),  // Not used
-    .axi_req_i    (sim_req      ),
-    .axi_resp_o   (sim_resp     ),
+    .axi_req_i    (axi_req_i    ),
+    .axi_resp_o   (axi_resp_o   ),
     .mem_req_o    (mem_req      ),
     .mem_gnt_i    (1'b1         ),  // ALWAYS GRANT: Sim SRAM is never busy
     .mem_addr_o   (mem_addr     ),
@@ -158,7 +120,7 @@ module sim_sram_axi_sink #(
 
   // Simulation SRAM Interface Instance
   sim_sram_axi_if u_sim_sram_if (.clk_i, .rst_ni);
-  assign u_sim_sram_if.req  = sim_req;
-  assign u_sim_sram_if.resp = sim_resp;
+  assign u_sim_sram_if.req  = axi_req_i;
+  assign u_sim_sram_if.resp = axi_resp_o;
 
 endmodule : sim_sram_axi_sink

--- a/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_sink.sv
+++ b/hw/top_chip/dv/sim_sram_axi/sim_sram_axi_sink.sv
@@ -68,6 +68,19 @@ module sim_sram_axi_sink #(
   logic [top_pkg::AxiDataWidth-1:0] mem_rdata;
   logic [top_pkg::AxiStrbWidth-1:0] mem_be;
 
+  // True when the access targets the read-only HW_ID register.
+  // axi_to_mem aligns addresses to AxiDataWidth/8 bytes, so compare against the
+  // 8-byte aligned hw_id_addr (clearing the lower 3 bits for a 64-bit bus).
+  logic hw_id_sel;
+  assign hw_id_sel = (mem_addr[31:0] == {u_sim_sram_if.hw_id_addr[31:3], 3'b000});
+
+  // Insert one cycle delay to align with mem_req_d
+  logic hw_id_sel_d;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) hw_id_sel_d <= 1'b0;
+    else         hw_id_sel_d <= mem_req && !mem_we && hw_id_sel;
+  end
+
   axi_to_mem #(
     .axi_req_t    (top_pkg::axi_req_t     ),
     .axi_resp_t   (top_pkg::axi_resp_t    ),
@@ -102,9 +115,9 @@ module sim_sram_axi_sink #(
     end
   end : delayed_mem_req
 
-  // Assert Error if ErrOnRead is set and a read occurs
+  // Assert Error if ErrOnRead is set and a read occurs to a non-HW_ID address.
   if (ErrOnRead) begin : gen_err_on_read
-    `ASSERT(ErrOnRead_A, mem_req |-> mem_we, clk_i, !rst_ni)
+    `ASSERT(ErrOnRead_A, (mem_req && !hw_id_sel) |-> mem_we, clk_i, !rst_ni)
   end : gen_err_on_read
 
   // Conditional SRAM Instantiation
@@ -138,9 +151,9 @@ module sim_sram_axi_sink #(
     );
   end : gen_sram
   else begin : gen_no_sram
-    // If no SRAM, return 0s on read.
-    // Handshaking is handled by the common logic and axi_to_mem.
-    assign mem_rdata = '0;
+    // If no SRAM, return hw_id for RO register reads, 0 otherwise.
+    // hw_id at byte offset 4 occupies the upper 32 bits of the 64-bit AXI word [63:32].
+    assign mem_rdata = hw_id_sel_d ? {u_sim_sram_if.hw_id, {(AxiDataWidth-32){1'b0}}} : '0;
   end : gen_no_sram
 
   // Simulation SRAM Interface Instance

--- a/hw/top_chip/dv/tb/tb.sv
+++ b/hw/top_chip/dv/tb/tb.sv
@@ -62,6 +62,10 @@ module tb;
   top_pkg::axi_dram_req_t  dram_req;
   top_pkg::axi_dram_resp_t dram_resp;
 
+  // ------ SW-DV window ------
+  top_pkg::axi_dev_req_t  sw_dv_req;
+  top_pkg::axi_dev_resp_t sw_dv_resp;
+
   dram_wrapper_sim u_dram_wrapper (
     // Clock and reset.
     .clk_i      (dut.clkmgr_clocks.clk_main_infra),
@@ -135,6 +139,9 @@ module tb;
     // DRAM.
     .dram_req_o           (dram_req         ),
     .dram_resp_i          (dram_resp        ),
+    // SW-DV window AXI.
+    .sw_dv_req_o          (sw_dv_req        ),
+    .sw_dv_resp_i         (sw_dv_resp       ),
     // Rest of chip AXI tie-off.
     .rest_of_chip_req_o   (                 ),
     .rest_of_chip_resp_i  ('0               ),
@@ -158,43 +165,13 @@ module tb;
   assign (strong0, weak1) scl = (scl_en_o) ? scl_o : 1'b1;
   assign (strong0, weak1) sda = (sda_en_o) ? sda_o : 1'b1;
 
-  // Signals to connect the sink
-  logic               sim_sram_clk;
-  logic               sim_sram_rst;
-  top_pkg::axi_req_t  sim_sram_cpu_req;
-  top_pkg::axi_resp_t sim_sram_cpu_resp;
-  top_pkg::axi_req_t  sim_sram_xbar_req;
-  top_pkg::axi_resp_t sim_sram_xbar_resp;
-
-  // CVA6 and Xbar uses clk_main_infra from clock manager and their request and response ports are
-  // interfaced in sim_sram_axi_sink module. Thus, use the same clock and reset as them to stay in
-  // sync.
-  assign sim_sram_clk = dut.clkmgr_clocks.clk_main_infra;
-  assign sim_sram_rst = dut.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel];
-
-  // Instantiate the AXI sink to intercept the AXI traffic within the simulation memory range
-  // to provide a dedicated channel for SW-to-DV communication.
+  // SW-DV sink: receives only SW-DV window traffic from the crossbar.
   sim_sram_axi_sink u_sim_sram (
-    .clk_i          (sim_sram_clk       ),
-    .rst_ni         (sim_sram_rst       ),
-    .cpu_req_i      (sim_sram_cpu_req   ),
-    .cpu_resp_o     (sim_sram_cpu_resp  ),
-    .xbar_req_o     (sim_sram_xbar_req  ),
-    .xbar_resp_i    (sim_sram_xbar_resp )
+    .clk_i      (dut.clkmgr_clocks.clk_main_infra                       ),
+    .rst_ni     (dut.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]),
+    .axi_req_i  (sw_dv_req                                              ),
+    .axi_resp_o (sw_dv_resp                                             )
   );
-
-  // Capture inputs FROM the DUT (Monitoring)
-  assign sim_sram_cpu_req   = dut.cva6_to_sim_req;
-  assign sim_sram_xbar_resp = dut.xbar_host_resp[top_pkg::CVA6];
-
-  // Force outputs INTO the DUT (Overriding)
-  // We break the direct connection inside the RTL using forces
-  initial begin
-    // Ensure we wait for build/elaboration phases if necessary,
-    // though force on static hierarchy works at time 0.
-    force dut.xbar_host_req[top_pkg::CVA6] = sim_sram_xbar_req;
-    force dut.sim_to_cva6_resp             = sim_sram_cpu_resp;
-  end
 
   // ------ Memory backdoor accesses ------
   if (prim_pkg::PrimTechName == "Generic") begin : gen_mem_bkdr_utils

--- a/hw/top_chip/dv/tb/tb.sv
+++ b/hw/top_chip/dv/tb/tb.sv
@@ -15,6 +15,8 @@ module tb;
   import top_chip_dv_env_pkg::SW_DV_START_ADDR;
   import top_chip_dv_env_pkg::SW_DV_TEST_STATUS_ADDR;
   import top_chip_dv_env_pkg::SW_DV_LOG_ADDR;
+  import top_chip_dv_env_pkg::SW_DV_HW_ID_ADDR;
+  import top_chip_dv_env_pkg::SW_DV_HW_ID;
 
   // Macro includes
   `include "uvm_macros.svh"
@@ -277,6 +279,8 @@ module tb;
     // Set base of SW DV special write locations
     `SIM_SRAM_IF.start_addr                              = SW_DV_START_ADDR;
     `SIM_SRAM_IF.sw_dv_size                              = SW_DV_SIZE;
+    `SIM_SRAM_IF.hw_id                                   = SW_DV_HW_ID;
+    `SIM_SRAM_IF.hw_id_addr                              = SW_DV_HW_ID_ADDR;
     `SIM_SRAM_IF.u_sw_test_status_if.sw_test_status_addr = SW_DV_TEST_STATUS_ADDR;
     `SIM_SRAM_IF.u_sw_logger_if.sw_log_addr              = SW_DV_LOG_ADDR;
 

--- a/hw/top_chip/dv/top_chip_sim.core
+++ b/hw/top_chip/dv/top_chip_sim.core
@@ -40,17 +40,9 @@ targets:
 
   sim:
     <<: *default_target
-    parameters:
-      - INST_SIM_SRAM=false
     filesets:
       - files_dv
     toplevel: tb
     # This is required as DVSim always expects a scr file, but in practice we are only running
     # fusesoc up to the point it generates the filelist file.
     default_tool: vcs
-
-parameters:
-  INST_SIM_SRAM:
-    datatype: bool
-    paramtype: vlogdefine
-    description: Disconnect the AXI data output of CVA6 core so that we can attach the simulation SRAM.

--- a/hw/top_chip/dv/top_chip_sim_cfg.hjson
+++ b/hw/top_chip/dv/top_chip_sim_cfg.hjson
@@ -104,6 +104,20 @@
                  "+ChipMemROM_image_file={run_dir}/bootrom_scrambled.vmem"]
     }
     {
+      name: test_framework_test
+      uvm_test_seq: top_chip_dv_base_vseq
+      sw_images: ["test_framework_test_vanilla_sram:5" "bootrom:5"]
+      run_opts: ["+ChipMemSRAM_image_file={run_dir}/test_framework_test_vanilla_sram.vmem",
+                 "+ChipMemROM_image_file={run_dir}/bootrom_scrambled.vmem"]
+    }
+    {
+      name: test_framework_test_cheri
+      uvm_test_seq: top_chip_dv_base_vseq
+      sw_images: ["test_framework_test_cheri_sram:5" "bootrom:5"]
+      run_opts: ["+ChipMemSRAM_image_file={run_dir}/test_framework_test_cheri_sram.vmem",
+                 "+ChipMemROM_image_file={run_dir}/bootrom_scrambled.vmem"]
+    }
+    {
       name: test_framework_exception_test
       uvm_test_seq: top_chip_dv_base_vseq
       sw_images: ["test_framework_exception_test_vanilla_sram:5" "bootrom:5"]
@@ -346,6 +360,8 @@
         "rv_timer_smoke_cheri",
         "rv_timer_irq",
         "rv_timer_irq_cheri",
+        "test_framework_test",
+        "test_framework_test_cheri",
         "test_framework_exception_test",
         "test_framework_exception_test_cheri",
         "spi_device_smoke",
@@ -398,6 +414,8 @@
     {
       name: test_framework
       tests: [
+        "test_framework_test",
+        "test_framework_test_cheri",
         "test_framework_exception_test",
         "test_framework_exception_test_cheri"
       ]

--- a/hw/top_chip/dv/verilator/top_chip_verilator.core
+++ b/hw/top_chip/dv/verilator/top_chip_verilator.core
@@ -45,8 +45,6 @@ targets:
 
   sim:
     <<: *default_target
-    parameters:
-      - INST_SIM_SRAM=true
     default_tool: verilator
     filesets_append:
       - files_verilator
@@ -79,9 +77,3 @@ targets:
     tools:
       verilator:
         mode: lint-only
-
-parameters:
-  INST_SIM_SRAM:
-    datatype: bool
-    paramtype: vlogdefine
-    description: Disconnect the AXI data output of CVA6 core so that we can attach the simulation SRAM.

--- a/hw/top_chip/dv/verilator/top_chip_verilator.sv
+++ b/hw/top_chip/dv/verilator/top_chip_verilator.sv
@@ -111,6 +111,9 @@ module top_chip_verilator (
     .dram_req_o  (dram_req),
     .dram_resp_i (dram_resp),
 
+    .sw_dv_req_o  (sw_dv_req),
+    .sw_dv_resp_i (sw_dv_resp),
+
     .rest_of_chip_req_o  ( ), // Rest of chip AXI tie-off
     .rest_of_chip_resp_i ('0),
 
@@ -216,15 +219,15 @@ module top_chip_verilator (
   `define DUT               u_top_chip_system
   `define SIM_SRAM_IF       u_sim_sram.u_sim_sram_if
 
+  // Special addresses for SW-DV communication
   localparam bit [31:0] VERILATOR_SW_DV_START_ADDR       = 'h2002_0000;
   localparam bit [31:0] VERILATOR_SW_DV_SIZE             = 'h0000_0100;   // 256 bytes reserved
   localparam bit [31:0] VERILATOR_SW_DV_TEST_STATUS_ADDR = VERILATOR_SW_DV_START_ADDR + 'h00;
+  localparam bit [31:0] VERILATOR_SW_DV_HW_ID_ADDR       = VERILATOR_SW_DV_START_ADDR + 'h04;
 
-  // Signals to connect the sink
-  top_pkg::axi_req_t  sim_sram_cpu_req;
-  top_pkg::axi_resp_t sim_sram_cpu_resp;
-  top_pkg::axi_req_t  sim_sram_xbar_req;
-  top_pkg::axi_resp_t sim_sram_xbar_resp;
+  // SW-DV window AXI signals: routed directly from the main crossbar via the dedicated port.
+  top_pkg::axi_req_t  sw_dv_req;
+  top_pkg::axi_resp_t sw_dv_resp;
 
   // Detect SW test termination.
   sim_sram_axi_sink u_sim_sram (
@@ -257,10 +260,12 @@ module top_chip_verilator (
     .data     (`SIM_SRAM_IF.req.w.data[15:0] )  // Test status is 16-bits wide
   );
 
-  // Set the start address and the size of the simulation SRAM
+  // Set special SW-DV registers
   initial begin
     `SIM_SRAM_IF.start_addr                 = VERILATOR_SW_DV_START_ADDR;
     `SIM_SRAM_IF.sw_dv_size                 = VERILATOR_SW_DV_SIZE;
+    `SIM_SRAM_IF.hw_id_addr                 = VERILATOR_SW_DV_HW_ID_ADDR;
+    `SIM_SRAM_IF.hw_id                      = top_pkg::HwIdSimVerilator;
     u_sw_test_status_if.sw_test_status_addr = VERILATOR_SW_DV_TEST_STATUS_ADDR;
   end
 

--- a/hw/top_chip/dv/verilator/top_chip_verilator.sv
+++ b/hw/top_chip/dv/verilator/top_chip_verilator.sv
@@ -226,27 +226,16 @@ module top_chip_verilator (
   localparam bit [31:0] VERILATOR_SW_DV_HW_ID_ADDR       = VERILATOR_SW_DV_START_ADDR + 'h04;
 
   // SW-DV window AXI signals: routed directly from the main crossbar via the dedicated port.
-  top_pkg::axi_req_t  sw_dv_req;
-  top_pkg::axi_resp_t sw_dv_resp;
+  top_pkg::axi_dev_req_t  sw_dv_req;
+  top_pkg::axi_dev_resp_t sw_dv_resp;
 
-  // Detect SW test termination.
+  // SW-DV sink: receives only SW-DV window traffic from the crossbar.
   sim_sram_axi_sink u_sim_sram (
-    .clk_i       (`DUT.clkmgr_clocks.clk_main_infra),
-    .rst_ni      (`DUT.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]),
-    .cpu_req_i   (sim_sram_cpu_req                 ),
-    .cpu_resp_o  (sim_sram_cpu_resp                ),
-    .xbar_req_o  (sim_sram_xbar_req                ),
-    .xbar_resp_i (sim_sram_xbar_resp               )
+    .clk_i      (`DUT.clkmgr_clocks.clk_main_infra                       ),
+    .rst_ni     (`DUT.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]),
+    .axi_req_i  (sw_dv_req                                               ),
+    .axi_resp_o (sw_dv_resp                                              )
   );
-
-  // Connect the sim SRAM directly at CVA6 AXI interface
-  assign `DUT.sim_to_cva6_resp = sim_sram_cpu_resp;
-  // Drive the request back into the DUT's Crossbar
-  assign `DUT.xbar_host_req[top_pkg::CVA6] = sim_sram_xbar_req;
-
-  // Capture inputs FROM the DUT (Monitoring)
-  assign sim_sram_cpu_req   = `DUT.cva6_to_sim_req;
-  assign sim_sram_xbar_resp = `DUT.xbar_host_resp[top_pkg::CVA6];
 
   // Instantiate the SW test status interface & connect signals from sim_sram_if instance
   // instantiated inside sim_sram. Bind would have worked nicely here, but Verilator segfaults

--- a/hw/top_chip/rtl/chip_mocha_genesys2.sv
+++ b/hw/top_chip/rtl/chip_mocha_genesys2.sv
@@ -97,7 +97,8 @@ module chip_mocha_genesys2 #(
   // Rest of chip AXI crossbar address mapping
   axi_pkg::xbar_rule_64_t [xbar_cfg.NoAddrRules-1:0] addr_map;
   assign addr_map = '{
-    '{ idx: top_pkg::Ethernet, start_addr: top_pkg::EthernetBase, end_addr: top_pkg::EthernetBase + top_pkg::EthernetLength }
+    '{ idx: top_pkg::SwDvWindowDevIdx, start_addr: top_pkg::SwDvWindowBase, end_addr: top_pkg::SwDvWindowBase + top_pkg::SwDvWindowLength },
+    '{ idx: top_pkg::Ethernet,         start_addr: top_pkg::EthernetBase,   end_addr: top_pkg::EthernetBase   + top_pkg::EthernetLength   }
   };
 
   // Internal clock signals
@@ -155,6 +156,14 @@ module chip_mocha_genesys2 #(
 
   // Ethernet interrupt line
   logic ethernet_irq;
+
+  // SW-DV window AXI subordinate memory interface acting as a sink
+  logic                             hw_id_mem_req;
+  logic                             hw_id_mem_req_q;
+  logic                             hw_id_mem_we;
+  logic [top_pkg::AxiAddrWidth-1:0] hw_id_mem_addr;
+  logic [top_pkg::AxiDataWidth-1:0] hw_id_mem_rdata;
+  logic                             hw_id_sel_q;
 
   // Clock generation
   clkgen_xil7series u_clk_gen (
@@ -297,6 +306,10 @@ module chip_mocha_genesys2 #(
     // DRAM
     .dram_req_o  (dram_req),
     .dram_resp_i (dram_resp),
+
+    // SW-DV window AXI
+    .sw_dv_req_o  (sw_dv_req),
+    .sw_dv_resp_i (sw_dv_resp),
 
     // Rest of chip AXI
     .rest_of_chip_req_o  (xbar_host_req[top_pkg::MochaAXICrossbar]),
@@ -582,5 +595,45 @@ module chip_mocha_genesys2 #(
     .eth_rgmii_mdio_io  (eth_mdio),
     .eth_rgmii_mdc_o    (eth_mdc)
   );
+
+  // SW-DV window: read-only HW_ID register.
+  // Uses the same axi_to_mem + 1-cycle loopback pattern as sim_sram_axi_sink.
+  // Writes are accepted and discarded. Reads return HwIdFpgaGenesys2 at offset +0x04, 0 elsewhere.
+  axi_to_mem #(
+    .axi_req_t    (top_pkg::axi_req_t   ),
+    .axi_resp_t   (top_pkg::axi_resp_t  ),
+    .DataWidth    (top_pkg::AxiDataWidth),
+    .AddrWidth    (top_pkg::AxiAddrWidth),
+    .IdWidth      (top_pkg::AxiIdWidth  ),
+    .NumBanks     (1                    )
+  ) u_hw_id_axi_to_mem (
+    .clk_i        (u_top_chip_system.clkmgr_clocks.clk_main_infra                       ),
+    .rst_ni       (u_top_chip_system.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]),
+    .busy_o       (                                                                     ),
+    .axi_req_i    (xbar_device_req [top_pkg::SwDvWindowDevIdx]                          ),
+    .axi_resp_o   (xbar_device_resp[top_pkg::SwDvWindowDevIdx]                          ),
+    .mem_req_o    (hw_id_mem_req                                                        ),
+    .mem_gnt_i    (1'b1                                                                 ),
+    .mem_addr_o   (hw_id_mem_addr                                                       ),
+    .mem_wdata_o  (                                                                     ),  // Ignored: RO register
+    .mem_strb_o   (                                                                     ),  // Ignored: RO register
+    .mem_atop_o   (                                                                     ),  // Not used
+    .mem_we_o     (hw_id_mem_we                                                         ),
+    .mem_rvalid_i (hw_id_mem_req_q                                                      ),
+    .mem_rdata_i  (hw_id_mem_rdata                                                      )
+  );
+
+  always_ff @(posedge u_top_chip_system.clkmgr_clocks.clk_main_infra
+              or negedge u_top_chip_system.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]) begin
+    if (!u_top_chip_system.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]) begin
+      hw_id_mem_req_q <= 1'b0;
+      hw_id_sel_q     <= 1'b0;
+    end else begin
+      hw_id_mem_req_q <= hw_id_mem_req;
+      hw_id_sel_q     <= hw_id_mem_req && !hw_id_mem_we && (hw_id_mem_addr[7:0] == 8'h00);
+    end
+  end
+
+  assign hw_id_mem_rdata = hw_id_sel_q ? {top_pkg::HwIdFpgaGenesys2, {(top_pkg::AxiDataWidth-32){1'b0}}} : '0;
 
 endmodule

--- a/hw/top_chip/rtl/chip_mocha_genesys2.sv
+++ b/hw/top_chip/rtl/chip_mocha_genesys2.sv
@@ -97,8 +97,7 @@ module chip_mocha_genesys2 #(
   // Rest of chip AXI crossbar address mapping
   axi_pkg::xbar_rule_64_t [xbar_cfg.NoAddrRules-1:0] addr_map;
   assign addr_map = '{
-    '{ idx: top_pkg::SwDvWindowDevIdx, start_addr: top_pkg::SwDvWindowBase, end_addr: top_pkg::SwDvWindowBase + top_pkg::SwDvWindowLength },
-    '{ idx: top_pkg::Ethernet,         start_addr: top_pkg::EthernetBase,   end_addr: top_pkg::EthernetBase   + top_pkg::EthernetLength   }
+    '{ idx: top_pkg::Ethernet, start_addr: top_pkg::EthernetBase, end_addr: top_pkg::EthernetBase + top_pkg::EthernetLength }
   };
 
   // Internal clock signals
@@ -158,6 +157,8 @@ module chip_mocha_genesys2 #(
   logic ethernet_irq;
 
   // SW-DV window AXI subordinate memory interface acting as a sink
+  top_pkg::axi_dev_req_t            sw_dv_req;
+  top_pkg::axi_dev_resp_t           sw_dv_resp;
   logic                             hw_id_mem_req;
   logic                             hw_id_mem_req_q;
   logic                             hw_id_mem_we;
@@ -600,18 +601,18 @@ module chip_mocha_genesys2 #(
   // Uses the same axi_to_mem + 1-cycle loopback pattern as sim_sram_axi_sink.
   // Writes are accepted and discarded. Reads return HwIdFpgaGenesys2 at offset +0x04, 0 elsewhere.
   axi_to_mem #(
-    .axi_req_t    (top_pkg::axi_req_t   ),
-    .axi_resp_t   (top_pkg::axi_resp_t  ),
-    .DataWidth    (top_pkg::AxiDataWidth),
-    .AddrWidth    (top_pkg::AxiAddrWidth),
-    .IdWidth      (top_pkg::AxiIdWidth  ),
-    .NumBanks     (1                    )
+    .axi_req_t    (top_pkg::axi_dev_req_t ),
+    .axi_resp_t   (top_pkg::axi_dev_resp_t),
+    .DataWidth    (top_pkg::AxiDataWidth  ),
+    .AddrWidth    (top_pkg::AxiAddrWidth  ),
+    .IdWidth      (top_pkg::AxiDevIdWidth ),
+    .NumBanks     (1                      )
   ) u_hw_id_axi_to_mem (
     .clk_i        (u_top_chip_system.clkmgr_clocks.clk_main_infra                       ),
     .rst_ni       (u_top_chip_system.rstmgr_resets.rst_main_n[rstmgr_pkg::DomainMainSel]),
     .busy_o       (                                                                     ),
-    .axi_req_i    (xbar_device_req [top_pkg::SwDvWindowDevIdx]                          ),
-    .axi_resp_o   (xbar_device_resp[top_pkg::SwDvWindowDevIdx]                          ),
+    .axi_req_i    (sw_dv_req                                                            ),
+    .axi_resp_o   (sw_dv_resp                                                           ),
     .mem_req_o    (hw_id_mem_req                                                        ),
     .mem_gnt_i    (1'b1                                                                 ),
     .mem_addr_o   (hw_id_mem_addr                                                       ),

--- a/hw/top_chip/rtl/top_chip_system.sv
+++ b/hw/top_chip/rtl/top_chip_system.sv
@@ -65,6 +65,10 @@ module top_chip_system #(
   output top_pkg::axi_dram_req_t  dram_req_o,
   input  top_pkg::axi_dram_resp_t dram_resp_i,
 
+  // SW-DV window AXI interface.
+  output top_pkg::axi_dev_req_t  sw_dv_req_o,
+  input  top_pkg::axi_dev_resp_t sw_dv_resp_i,
+
   // Rest of chip AXI interface.
   output top_pkg::axi_dev_req_t  rest_of_chip_req_o,
   input  top_pkg::axi_dev_resp_t rest_of_chip_resp_i,
@@ -153,6 +157,7 @@ module top_chip_system #(
     '{ idx: top_pkg::SRAM,       start_addr: top_pkg::SRAMBase,       end_addr: top_pkg::SRAMBase       + top_pkg::SRAMLength       },
     '{ idx: top_pkg::DM_DEV,     start_addr: top_pkg::DebugMemBase,   end_addr: top_pkg::DebugMemBase   + top_pkg::DebugMemLength   },
     '{ idx: top_pkg::Mailbox,    start_addr: top_pkg::MailboxBase,    end_addr: top_pkg::MailboxBase    + top_pkg::MailboxLength    },
+    '{ idx: top_pkg::SwDvWindow, start_addr: top_pkg::SwDvWindowBase, end_addr: top_pkg::SwDvWindowBase + top_pkg::SwDvWindowLength },
     '{ idx: top_pkg::RestOfChip, start_addr: top_pkg::RestOfChipBase, end_addr: top_pkg::RestOfChipBase + top_pkg::RestOfChipLength },
     '{ idx: top_pkg::TlCrossbar, start_addr: top_pkg::TlCrossbarBase, end_addr: top_pkg::TlCrossbarBase + top_pkg::TlCrossbarLength },
     '{ idx: top_pkg::DRAM,       start_addr: top_pkg::DRAMBase,       end_addr: top_pkg::DRAMBase       + top_pkg::DRAMUsableLength }
@@ -300,9 +305,6 @@ module top_chip_system #(
   logic [1:0] intr;
   logic       debug_req_irq;
 
-  // Signals to intercept AXI traffic from CVA6 for DV puprose
-  top_pkg::axi_req_t  cva6_to_sim_req;
-  top_pkg::axi_resp_t sim_to_cva6_resp;
 
   // Define the signals used by the clock, reset and power managers.
   clkmgr_pkg::clkmgr_cg_en_t  clkmgr_cg_en;
@@ -397,8 +399,8 @@ module top_chip_system #(
     .rvfi_probes_o ( ),
     .cvxif_req_o   ( ),
     .cvxif_resp_i  ('0),
-    .noc_req_o     (cva6_to_sim_req),
-    .noc_resp_i    (sim_to_cva6_resp)
+    .noc_req_o     (xbar_host_req[top_pkg::CVA6]),
+    .noc_resp_i    (xbar_host_resp[top_pkg::CVA6])
   );
 
   // JTAG to DMI bridge
@@ -531,19 +533,6 @@ module top_chip_system #(
     .dmi_resp_o           (debug_resp)
   );
 
-  // Interception point for connecting simulation SRAM by disconnecting the AXI output. The
-  // disconnection is done only if `SYNTHESIS is NOT defined AND `INST_SIM_SRAM is defined.
-  // This define is used only for Verilator as it does not support forces.
-`ifdef INST_SIM_SRAM
-`ifdef SYNTHESIS
-  // Induce a compilation error by instantiating a non-existent module.
-  illegal_preprocessor_branch_taken u_illegal_preprocessor_branch_taken ();
-`endif
-`else
-  assign xbar_host_req[top_pkg::CVA6] = cva6_to_sim_req;
-  assign sim_to_cva6_resp             = xbar_host_resp[top_pkg::CVA6];
-`endif
-
   // AXI SRAM
   axi_sram #(
     .AddrWidth   ( SramAddrWidth         ),
@@ -556,6 +545,10 @@ module top_chip_system #(
     .axi_req_i  (xbar_device_req[top_pkg::SRAM]),
     .axi_resp_o (xbar_device_resp[top_pkg::SRAM])
   );
+
+  // SW-DV window AXI passthrough
+  assign sw_dv_req_o                           = xbar_device_req[top_pkg::SwDvWindow];
+  assign xbar_device_resp[top_pkg::SwDvWindow] = sw_dv_resp_i;
 
   // Rest of chip AXI passthrough
   assign rest_of_chip_req_o                    = xbar_device_req[top_pkg::RestOfChip];

--- a/hw/top_chip/rtl/top_pkg.sv
+++ b/hw/top_chip/rtl/top_pkg.sv
@@ -33,7 +33,7 @@ package top_pkg;
 
   // Mocha AXI crossbar parameters
   localparam int AxiXbarHosts   = 2;
-  localparam int AxiXbarDevices = 7;
+  localparam int AxiXbarDevices = 8;
 
   // Mocha AXI crossbar hosts and devices
   typedef enum int unsigned {
@@ -46,9 +46,10 @@ package top_pkg;
     SRAM       = 1,
     DM_DEV     = 2,
     Mailbox    = 3,
-    RestOfChip = 4,
-    TlCrossbar = 5,
-    DRAM       = 6
+    SwDvWindow = 4,
+    RestOfChip = 5,
+    TlCrossbar = 6,
+    DRAM       = 7
   } axi_devices_t;
 
   parameter int unsigned DebugMemBase32 = 32'h2000_0000;
@@ -58,7 +59,8 @@ package top_pkg;
     SRAMBase       = 64'h1000_0000,
     DebugMemBase   = {32'h0, DebugMemBase32},
     MailboxBase    = 64'h2001_0000,
-    RestOfChipBase = 64'h2002_0000,
+    SwDvWindowBase = 64'h2002_0000,
+    RestOfChipBase = 64'h3000_0000,
     TlCrossbarBase = 64'h4000_0000,
     DRAMBase       = 64'h8000_0000
   } axi_addr_start_t;
@@ -68,7 +70,8 @@ package top_pkg;
   localparam longint unsigned SRAMLength         = 64'h0002_0000;
   localparam longint unsigned DebugMemLength     = 64'h0000_1000;
   localparam longint unsigned MailboxLength      = 64'h0001_0000;
-  localparam longint unsigned RestOfChipLength   = 64'h0FFE_8000;   // 0x2002_0000 to 0x3000_7FFF
+  localparam longint unsigned SwDvWindowLength   = 64'h0000_0100;
+  localparam longint unsigned RestOfChipLength   = 64'h0000_8000;
   localparam longint unsigned TlCrossbarLength   = 64'h1000_0000;
   localparam longint unsigned DRAMPhysicalLength = 64'h4000_0000;
 
@@ -87,7 +90,7 @@ package top_pkg;
 
   // Rest of chip AXI crossbar parameters
   localparam int RestOfChipAxiXbarHosts   = 1;
-  localparam int RestOfChipAxiXbarDevices = 2;
+  localparam int RestOfChipAxiXbarDevices = 1;
 
   // Rest of chip AXI crossbar hosts and devices
   typedef enum int unsigned {
@@ -95,18 +98,15 @@ package top_pkg;
   } rest_of_chip_axi_hosts_t;
 
   typedef enum int unsigned {
-    Ethernet         = 0,
-    SwDvWindowDevIdx = 1
+    Ethernet = 0
   } rest_of_chip_axi_devices_t;
 
   typedef enum longint unsigned {
-    EthernetBase   = 64'h3000_0000,
-    SwDvWindowBase = 64'h2002_0000
+    EthernetBase = 64'h3000_0000
   } rest_of_chip_axi_addr_start_t;
 
   // Memory lengths
-  localparam longint unsigned EthernetLength   = 64'h0000_8000;
-  localparam longint unsigned SwDvWindowLength = 64'h0000_0100;
+  localparam longint unsigned EthernetLength = 64'h0000_8000;
 
   // Memory address masks
   localparam longint unsigned EthernetMask = EthernetLength - 1;

--- a/hw/top_chip/rtl/top_pkg.sv
+++ b/hw/top_chip/rtl/top_pkg.sv
@@ -72,6 +72,11 @@ package top_pkg;
   localparam longint unsigned TlCrossbarLength   = 64'h1000_0000;
   localparam longint unsigned DRAMPhysicalLength = 64'h4000_0000;
 
+  // HW identifiers for the sw_dv window hw_id register
+  localparam logic [31:0] HwIdFpgaGenesys2 = 32'h0000_000A;
+  localparam logic [31:0] HwIdSimVerilator = 32'h0000_001A;
+  localparam logic [31:0] HwIdSimUvm       = 32'h0000_002A;
+
   // Memory address masks
   localparam longint unsigned RomCtrlMemMask = RomCtrlMemLength - 1;
   localparam longint unsigned SRAMMask       = SRAMLength - 1;

--- a/hw/top_chip/rtl/top_pkg.sv
+++ b/hw/top_chip/rtl/top_pkg.sv
@@ -58,7 +58,7 @@ package top_pkg;
     SRAMBase       = 64'h1000_0000,
     DebugMemBase   = {32'h0, DebugMemBase32},
     MailboxBase    = 64'h2001_0000,
-    RestOfChipBase = 64'h3000_0000,
+    RestOfChipBase = 64'h2002_0000,
     TlCrossbarBase = 64'h4000_0000,
     DRAMBase       = 64'h8000_0000
   } axi_addr_start_t;
@@ -68,7 +68,7 @@ package top_pkg;
   localparam longint unsigned SRAMLength         = 64'h0002_0000;
   localparam longint unsigned DebugMemLength     = 64'h0000_1000;
   localparam longint unsigned MailboxLength      = 64'h0001_0000;
-  localparam longint unsigned RestOfChipLength   = 64'h0000_8000;
+  localparam longint unsigned RestOfChipLength   = 64'h0FFE_8000;   // 0x2002_0000 to 0x3000_7FFF
   localparam longint unsigned TlCrossbarLength   = 64'h1000_0000;
   localparam longint unsigned DRAMPhysicalLength = 64'h4000_0000;
 
@@ -87,7 +87,7 @@ package top_pkg;
 
   // Rest of chip AXI crossbar parameters
   localparam int RestOfChipAxiXbarHosts   = 1;
-  localparam int RestOfChipAxiXbarDevices = 1;
+  localparam int RestOfChipAxiXbarDevices = 2;
 
   // Rest of chip AXI crossbar hosts and devices
   typedef enum int unsigned {
@@ -95,15 +95,18 @@ package top_pkg;
   } rest_of_chip_axi_hosts_t;
 
   typedef enum int unsigned {
-    Ethernet = 0
+    Ethernet         = 0,
+    SwDvWindowDevIdx = 1
   } rest_of_chip_axi_devices_t;
 
   typedef enum longint unsigned {
-    EthernetBase = 64'h3000_0000
+    EthernetBase   = 64'h3000_0000,
+    SwDvWindowBase = 64'h2002_0000
   } rest_of_chip_axi_addr_start_t;
 
   // Memory lengths
-  localparam longint unsigned EthernetLength = 64'h0000_8000;
+  localparam longint unsigned EthernetLength   = 64'h0000_8000;
+  localparam longint unsigned SwDvWindowLength = 64'h0000_0100;
 
   // Memory address masks
   localparam longint unsigned EthernetMask = EthernetLength - 1;

--- a/sw/device/lib/hal/dv.h
+++ b/sw/device/lib/hal/dv.h
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors (COSMIC project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Design Verification (DV) register window.
+
+#pragma once
+
+#include <stdint.h>
+
+/* These values are written to the test_status register of the DV window
+ * throughout a test to indicate test progression and outcome. */
+enum dv_test_status : uint32_t {
+    /* Test code has begun. */
+    dv_test_status_in_test = 0x4354u,
+    /* The test has passed. */
+    dv_test_status_passed = 0x900du,
+    /* The test has failed. */
+    dv_test_status_failed = 0xbaadu,
+};
+
+/* These values are provided by the DV window from the hw_id register to
+ * indicate the current test platform. */
+enum dv_hwid : uint32_t {
+    /* Running on the Genesys2 FPGA. */
+    dv_hwid_fpga_genesys2 = 0xau,
+    /* Running in a Verilator simulation. */
+    dv_hwid_sim_verilator = 0x1au,
+    /* Running in a UVM simulation. */
+    dv_hwid_sim_uvm = 0x2au,
+};
+
+typedef volatile struct [[gnu::aligned(4)]] dv_window_memory_layout {
+    /* test_status (0x0) */
+    uint32_t test_status;
+
+    /* hw_id (0x4) */
+    const uint32_t hw_id;
+
+    const uint8_t __reserved0[0x100 - 0x08];
+} *dv_window_t;
+
+
+_Static_assert(__builtin_offsetof(struct dv_window_memory_layout, test_status) == 0x0ul,
+               "incorrect register test_status offset");
+_Static_assert(__builtin_offsetof(struct dv_window_memory_layout, hw_id) == 0x4ul,
+               "incorrect register hw_id offset");

--- a/sw/device/lib/hal/mocha.c
+++ b/sw/device/lib/hal/mocha.c
@@ -13,7 +13,7 @@
 
 static const uintptr_t rom_base = 0x80000ul;
 static const uintptr_t mailbox_base = 0x20010000ul;
-static const uintptr_t dv_test_status_base = 0x20020000ul;
+static const uintptr_t dv_window_base = 0x20020000ul;
 static const uintptr_t ethernet_base = 0x30000000ul;
 static const uintptr_t gpio_base = 0x40000000ul;
 static const uintptr_t clkmgr_base = 0x40020000ul;
@@ -193,11 +193,12 @@ void *mocha_system_dram(void)
 #endif /* defined(__riscv_zcherihybrid) */
 }
 
-void *mocha_system_dv_test_status(void)
+dv_window_t mocha_system_dv_window(void)
 {
 #if defined(__riscv_zcherihybrid)
-    return create_mmio_capability(dv_test_status_base, 0x100u);
+    return (
+        dv_window_t)create_mmio_capability(dv_window_base, sizeof(struct dv_window_memory_layout));
 #else /* !defined(__riscv_zcherihybrid) */
-    return (void *)dv_test_status_base;
+    return (dv_window_t)dv_window_base;
 #endif /* defined(__riscv_zcherihybrid) */
 }

--- a/sw/device/lib/hal/mocha.h
+++ b/sw/device/lib/hal/mocha.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "hal/clkmgr.h"
+#include "hal/dv.h"
 #include "hal/entropy_src.h"
 #include "hal/ethernet.h"
 #include "hal/gpio.h"
@@ -50,5 +51,4 @@ timer_t mocha_system_timer(void);
 spi_host_t mocha_system_spi_host(void);
 plic_t mocha_system_plic(void);
 void *mocha_system_dram(void);
-
-void *mocha_system_dv_test_status(void);
+dv_window_t mocha_system_dv_window(void);

--- a/sw/device/lib/test_framework/main.c
+++ b/sw/device/lib/test_framework/main.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "boot/trap.h"
+#include "hal/dv.h"
 #include "hal/hart.h"
 #include "hal/mmio.h"
 #include "hal/mocha.h"
@@ -11,12 +12,6 @@
 #include "runtime/string.h"
 #include <stdbool.h>
 #include <stdint.h>
-
-enum test_status {
-    TEST_STATUS_IN_TEST = 0x4354u,
-    TEST_STATUS_PASSED = 0x900du,
-    TEST_STATUS_FAILED = 0xbaadu,
-};
 
 /* magic byte string to terminate the verilator simulation */
 static const char magic[] = "\xd8\xaf\xfb\xa0\xc7\xe1\xa9\xd7";
@@ -53,11 +48,11 @@ test_exception_handler(struct trap_registers *registers, struct trap_context *co
 [[noreturn]] void test_exit(bool success)
 {
     uart_t console = mocha_system_uart();
-    void *dv_test_status = mocha_system_dv_test_status();
+    dv_window_t dv_window = mocha_system_dv_window();
 
     uart_puts(console, "TEST RESULT: ");
     uart_puts(console, success ? "PASSED" : "FAILED");
-    DEV_WRITE(dv_test_status, success ? TEST_STATUS_PASSED : TEST_STATUS_FAILED);
+    DEV_WRITE(&dv_window->test_status, success ? dv_test_status_passed : dv_test_status_failed);
 
     uart_putchar(console, '\n');
     uart_puts(console, "Safe to exit simulator.");
@@ -75,12 +70,13 @@ test_exception_handler(struct trap_registers *registers, struct trap_context *co
 [[noreturn]] void main(void)
 {
     uart_t console = mocha_system_uart();
-    void *dv_test_status = mocha_system_dv_test_status();
+    dv_window_t dv_window = mocha_system_dv_window();
 
     uart_init(console);
     // Flush the uart
     uart_wait_for(console, uart_status_txidle);
-    DEV_WRITE(dv_test_status, TEST_STATUS_IN_TEST);
+
+    DEV_WRITE(&dv_window->test_status, dv_test_status_in_test);
 
     bool result = test_main(console);
     // Flush the uart

--- a/sw/device/tests/test_framework/smoketest.c
+++ b/sw/device/tests/test_framework/smoketest.c
@@ -2,11 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hal/dv.h"
+#include "hal/mocha.h"
 #include "hal/uart.h"
 #include <stdbool.h>
 
 bool test_main(uart_t console)
 {
+    dv_window_t dv_window = mocha_system_dv_window();
+    uint32_t hwid = DEV_READ(&dv_window->hw_id);
+
     uart_puts(console, "Test framework smoketest\n");
+
+    switch (hwid) {
+    case dv_hwid_fpga_genesys2:
+        uart_puts(console, "Platform: Genesys2 FPGA\n");
+        break;
+    case dv_hwid_sim_verilator:
+        uart_puts(console, "Platform: Verilator Simulation\n");
+        break;
+    case dv_hwid_sim_uvm:
+        uart_puts(console, "Platform: UVM Simulation\n");
+        break;
+    default:
+        uart_puts(console, "Unknown Hardware ID\n");
+        return false;
+    }
+
     return true;
 }


### PR DESCRIPTION
- Related to issue #423
- This commit adds support for a HW_ID register that can be used by SW DV tests to identify the hardware they are running on. This is useful for SW DV tests that need to run on multiple hardware platforms and need a way to differentiate between them.