### PR TITLE
[doc] Move badge domain from dashboards to dashboard.reports

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/prim/README.md
+++ b/hw/vendor/lowrisc_ip/ip/prim/README.md
@@ -1,30 +1,30 @@
 # lowRISC Hardware Primitives
 
 [`prim_alert`](https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/code.svg)<br>
 [`prim_esc`](https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/code.svg)<br>
 [`prim_lfsr`](https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/code.svg)<br>
 [`prim_present`](https://reports.opentitan.org/hw/ip/prim/dv/prim_present/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/code.svg)<br>
 [`prim_prince`](https://reports.opentitan.org/hw/ip/prim/dv/prim_prince/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/code.svg)<br>
 
 ## Concepts
 

--- a/hw/vendor/patches/lowrisc_ip/prim/0004_fix_badge_urls.patch
+++ b/hw/vendor/patches/lowrisc_ip/prim/0004_fix_badge_urls.patch
@@ -1,0 +1,55 @@
+diff --git a/README.md b/README.md
+index fc654fb..9cd8223 100644
+--- a/README.md
++++ b/README.md
+@@ -1,30 +1,30 @@
+ # lowRISC Hardware Primitives
+
+ [`prim_alert`](https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/report.html):
+-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/test.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/passing.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/functional.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/code.svg)<br>
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/test.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/passing.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/functional.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/code.svg)<br>
+ [`prim_esc`](https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/report.html):
+-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/test.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/passing.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/functional.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/code.svg)<br>
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/test.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/passing.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/functional.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/code.svg)<br>
+ [`prim_lfsr`](https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/report.html):
+-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/test.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/code.svg)<br>
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/test.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/code.svg)<br>
+ [`prim_present`](https://reports.opentitan.org/hw/ip/prim/dv/prim_present/latest/report.html):
+-![](https://dashboards.lowrisc.org/badges/dv/prim_present/test.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_present/passing.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_present/functional.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_present/code.svg)<br>
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/test.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/passing.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/functional.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/code.svg)<br>
+ [`prim_prince`](https://reports.opentitan.org/hw/ip/prim/dv/prim_prince/latest/report.html):
+-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/test.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/passing.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/functional.svg)
+-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/code.svg)<br>
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/test.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/passing.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/functional.svg)
++![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/code.svg)<br>
+
+ ## Concepts
+


### PR DESCRIPTION
Soon badges will be migrating from the `dashboards.lowrisc.org` domain to the `dashboard.reports.lowrisc.org`. For now they exist in both but to get ahead of the migration it makes sense to change them now.