### PR TITLE
[uart,dv] Fix UART prints on the TX port

### DIFF
--- a/hw/top_chip/dv/env/seq_lib/top_chip_dv_uart_base_vseq.sv
+++ b/hw/top_chip/dv/env/seq_lib/top_chip_dv_uart_base_vseq.sv
@@ -10,9 +10,13 @@ class top_chip_dv_uart_base_vseq extends top_chip_dv_base_vseq;
   // Local queue for holding received UART TX data.
   byte uart_tx_data_q[$];
 
+  // Buffer holding the current incomplete UART TX line, flushed in post_body().
+  string uart_tx_line_buf = "";
+
   // Standard SV/UVM methods
   extern function new(string name = "");
   extern task body();
+  extern task post_body();
 
   // Class specific methods
   extern function void configure_uart_agent(bit enable,
@@ -33,6 +37,9 @@ task top_chip_dv_uart_base_vseq::body();
   super.body();
   `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
   configure_uart_agent(.enable(1), .enable_rx_monitor(1));
+  fork
+    get_uart_tx_items();
+  join_none
 endtask : body
 
 // Configures and connects the UART agent for driving data over RX and receiving data on TX.
@@ -66,13 +73,30 @@ function void top_chip_dv_uart_base_vseq::configure_uart_agent(
   end
 endfunction : configure_uart_agent
 
-// Grab packets sent by the DUT over the UART TX port
+// Grab packets sent by the DUT over the UART TX port, print complete lines
 task top_chip_dv_uart_base_vseq::get_uart_tx_items();
   uart_item item;
 
   forever begin
     p_sequencer.uart_tx_fifo.get(item);
-    `uvm_info(`gfn, $sformatf("Received UART data over TX:\n%0h", item.data), UVM_HIGH)
+    if (item.data == "\n") begin
+      `uvm_info("UART_TRACE", $sformatf("Received UART data over TX: %0s", uart_tx_line_buf), UVM_LOW)
+      uart_tx_line_buf = "";
+    end else if (item.data == 8'h0d) begin
+      // Discard carriage returns from \r\n line endings
+    end else if (item.data >= 8'h20 && item.data <= 8'h7e) begin
+      uart_tx_line_buf = {uart_tx_line_buf, string'(item.data)};
+    end else begin
+      uart_tx_line_buf = {uart_tx_line_buf, $sformatf("\\x%02h", item.data)};
+    end
     uart_tx_data_q.push_back(item.data);
   end
 endtask : get_uart_tx_items
+
+// Flush any partial UART TX line that did not end with a newline.
+task top_chip_dv_uart_base_vseq::post_body();
+  if (uart_tx_line_buf != "") begin
+    `uvm_info("UART_TRACE", $sformatf("Received UART data over TX (partial line): %0s", uart_tx_line_buf), UVM_LOW)
+  end
+  super.post_body();
+endtask : post_body


### PR DESCRIPTION
- UART prints on the TX port are now printed at UVM_LOW, and complete lines are printed instead of individual characters. This makes it easier to read the UART output in the logs.

Now we'll have messages like:
```
UVM_INFO @            947352341: (top_chip_dv_uart_base_vseq.sv:83) uvm_test_top.env.top_vsqr [UART_TRACE] Received UART data over TX: TEST RESULT: PASSED
```

To verify the change I have run this test:
`dvsim hw/top_chip/dv/top_chip_sim_cfg.hjson -i uart_smoke`