### PR TITLE
[ci] Merge queue rules to avoid merge skew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This requires CI to run in serial and avoid having to enforce that pull requests must be made up to date before merging.

After this pull request is merged, I will enable the "enforce merge queue" option for this repository in GitHub.