### PR TITLE
[hw] Rework reset tree for non-debug-module reset

### DIFF
--- a/hw/top_chip/data/rstmgr_cfg.hjson
+++ b/hw/top_chip/data/rstmgr_cfg.hjson
@@ -112,7 +112,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_main_n
-        parent: sys_src
+        parent: lc_src
         clock: main
       }
       {
@@ -126,7 +126,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_io_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -140,7 +140,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_device_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -154,7 +154,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_host_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -168,8 +168,22 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_i2c_n
-        parent: sys_src
+        parent: lc_src
         clock: io
+      }
+      {
+        name: debug
+        gen: true
+        type: top
+        domains:
+        [
+          Main
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_debug_n
+        parent: sys_src
+        clock: main
       }
     ]
     leaf_rsts:
@@ -213,7 +227,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_main_n
-        parent: sys_src
+        parent: lc_src
         clock: main
       }
       {
@@ -227,7 +241,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_io_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -241,7 +255,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_device_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -255,7 +269,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_host_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -269,8 +283,22 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_i2c_n
-        parent: sys_src
+        parent: lc_src
         clock: io
+      }
+      {
+        name: debug
+        gen: true
+        type: top
+        domains:
+        [
+          Main
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_debug_n
+        parent: sys_src
+        clock: main
       }
     ]
     rst_ni: sys_src

--- a/hw/top_chip/data/rstmgr_cfg.hjson
+++ b/hw/top_chip/data/rstmgr_cfg.hjson
@@ -108,6 +108,7 @@
         domains:
         [
           Main
+          Aon
         ]
         shadowed: false
         sw: false
@@ -116,12 +117,27 @@
         clock: main
       }
       {
+        name: aon
+        gen: true
+        type: top
+        domains:
+        [
+          Aon
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_aon_n
+        parent: lc_src
+        clock: aon
+      }
+      {
         name: io
         gen: true
         type: top
         domains:
         [
           Main
+          Aon
         ]
         shadowed: false
         sw: false
@@ -229,6 +245,20 @@
         path: rstmgr_aon_resets.rst_main_n
         parent: lc_src
         clock: main
+      }
+      {
+        name: aon
+        gen: true
+        type: top
+        domains:
+        [
+          Aon
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_aon_n
+        parent: lc_src
+        clock: aon
       }
       {
         name: io

--- a/hw/top_chip/ip_autogen/rstmgr/data/mocha_rstmgr.ipconfig.hjson
+++ b/hw/top_chip/ip_autogen/rstmgr/data/mocha_rstmgr.ipconfig.hjson
@@ -112,7 +112,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_main_n
-        parent: sys_src
+        parent: lc_src
         clock: main
       }
       {
@@ -126,7 +126,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_io_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -140,7 +140,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_device_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -154,7 +154,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_host_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -168,8 +168,22 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_i2c_n
-        parent: sys_src
+        parent: lc_src
         clock: io
+      }
+      {
+        name: debug
+        gen: true
+        type: top
+        domains:
+        [
+          Main
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_debug_n
+        parent: sys_src
+        clock: main
       }
     ]
     leaf_rsts:
@@ -213,7 +227,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_main_n
-        parent: sys_src
+        parent: lc_src
         clock: main
       }
       {
@@ -227,7 +241,7 @@
         shadowed: false
         sw: false
         path: rstmgr_aon_resets.rst_io_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -241,7 +255,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_device_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -255,7 +269,7 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_host_n
-        parent: sys_src
+        parent: lc_src
         clock: io
       }
       {
@@ -269,8 +283,22 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_i2c_n
-        parent: sys_src
+        parent: lc_src
         clock: io
+      }
+      {
+        name: debug
+        gen: true
+        type: top
+        domains:
+        [
+          Main
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_debug_n
+        parent: sys_src
+        clock: main
       }
     ]
     rst_ni: sys_src

--- a/hw/top_chip/ip_autogen/rstmgr/data/mocha_rstmgr.ipconfig.hjson
+++ b/hw/top_chip/ip_autogen/rstmgr/data/mocha_rstmgr.ipconfig.hjson
@@ -108,6 +108,7 @@
         domains:
         [
           Main
+          Aon
         ]
         shadowed: false
         sw: false
@@ -116,12 +117,27 @@
         clock: main
       }
       {
+        name: aon
+        gen: true
+        type: top
+        domains:
+        [
+          Aon
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_aon_n
+        parent: lc_src
+        clock: aon
+      }
+      {
         name: io
         gen: true
         type: top
         domains:
         [
           Main
+          Aon
         ]
         shadowed: false
         sw: false
@@ -229,6 +245,20 @@
         path: rstmgr_aon_resets.rst_main_n
         parent: lc_src
         clock: main
+      }
+      {
+        name: aon
+        gen: true
+        type: top
+        domains:
+        [
+          Aon
+        ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_aon_n
+        parent: lc_src
+        clock: aon
       }
       {
         name: io

--- a/hw/top_chip/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
@@ -12,6 +12,8 @@
 -module_node rstmgr rst_en_o.por_io[DomainMainSel]
 -module_node rstmgr resets_o.rst_main_n[DomainAonSel]
 -module_node rstmgr rst_en_o.main[DomainAonSel]
+-module_node rstmgr resets_o.rst_aon_n[DomainMainSel]
+-module_node rstmgr rst_en_o.aon[DomainMainSel]
 -module_node rstmgr resets_o.rst_io_n[DomainAonSel]
 -module_node rstmgr rst_en_o.io[DomainAonSel]
 -module_node rstmgr resets_o.rst_spi_device_n[DomainAonSel]

--- a/hw/top_chip/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
@@ -20,3 +20,5 @@
 -module_node rstmgr rst_en_o.spi_host[DomainAonSel]
 -module_node rstmgr resets_o.rst_i2c_n[DomainAonSel]
 -module_node rstmgr rst_en_o.i2c[DomainAonSel]
+-module_node rstmgr resets_o.rst_debug_n[DomainAonSel]
+-module_node rstmgr rst_en_o.debug[DomainAonSel]

--- a/hw/top_chip/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -37,6 +37,7 @@ package rstmgr_env_pkg;
   parameter string LIST_OF_LEAFS[] = {
     "u_daon_por",
     "u_daon_por_io",
+    "u_dmain_debug",
     "u_dmain_i2c",
     "u_dmain_io",
     "u_dmain_main",

--- a/hw/top_chip/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -35,6 +35,7 @@ package rstmgr_env_pkg;
 
   // Sorted instances of rstmgr_leaf_rst instances with security checks enabled.
   parameter string LIST_OF_LEAFS[] = {
+    "u_daon_aon",
     "u_daon_por",
     "u_daon_por_io",
     "u_dmain_debug",

--- a/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -159,16 +159,22 @@ interface rstmgr_cascading_sva_if (
                     resets_o.rst_por_n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_main_i)
 
   // Controlled by rst_lc_src_n.
-  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
-                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
-  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeLcToAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
+                    resets_o.rst_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
+  `CASCADED_ASSERTS(CascadeLcToMain, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeLcToIo, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeLcToSpiDevice, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeLcToSpiHost, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeLcToI2c, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
 
   // Controlled by rst_sys_src_n.
-  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeSysToDebug, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_debug_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
 
   `undef FALL_ASSERT
   `undef RISE_ASSERTS

--- a/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -158,21 +158,17 @@ interface rstmgr_cascading_sva_if (
   `CASCADED_ASSERTS(CascadeEffAonToRstPorMain, effective_aon_rst_n[rstmgr_pkg::DomainAonSel],
                     resets_o.rst_por_n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_main_i)
 
+  // Controlled by rst_lc_src_n.
+  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
+                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
+  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+
   // Controlled by rst_sys_src_n.
-  `CASCADED_ASSERTS(CascadeSysToMain_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-
-  `CASCADED_ASSERTS(CascadeSysToIO_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-
-  `CASCADED_ASSERTS(CascadeSysToSPIHost_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-
-  `CASCADED_ASSERTS(CascadeSysToSPIDevice_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-
-  `CASCADED_ASSERTS(CascadeSysToI2C_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
 
   `undef FALL_ASSERT
   `undef RISE_ASSERTS

--- a/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv
@@ -133,4 +133,17 @@ interface rstmgr_rst_en_track_sva_if (
           clk_io_i,
           !rst_por_ni)
 
+  `ASSERT(DMainRstDebugEnTracksRstDebugActive_A,
+          $fell(resets_i.rst_debug_n[DomainMainSel]) |-> ##[0:DELAY]
+          reset_en_i.debug[DomainMainSel] == prim_mubi_pkg::MuBi4True,
+          clk_main_i,
+          !rst_por_ni)
+
+  `ASSERT(DMainRstDebugEnTracksRstDebugInactive_A,
+          $rose(resets_i.rst_debug_n[DomainMainSel]) |-> ##DELAY
+          !resets_i.rst_debug_n[DomainMainSel] ||
+          reset_en_i.debug[DomainMainSel] == prim_mubi_pkg::MuBi4False,
+          clk_main_i,
+          !rst_por_ni)
+
 endinterface

--- a/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv
@@ -81,6 +81,32 @@ interface rstmgr_rst_en_track_sva_if (
           clk_main_i,
           !rst_por_ni)
 
+  `ASSERT(DAonRstMainEnTracksRstMainActive_A,
+          $fell(resets_i.rst_main_n[DomainAonSel]) |-> ##[0:DELAY]
+          reset_en_i.main[DomainAonSel] == prim_mubi_pkg::MuBi4True,
+          clk_main_i,
+          !rst_por_ni)
+
+  `ASSERT(DAonRstMainEnTracksRstMainInactive_A,
+          $rose(resets_i.rst_main_n[DomainAonSel]) |-> ##DELAY
+          !resets_i.rst_main_n[DomainAonSel] ||
+          reset_en_i.main[DomainAonSel] == prim_mubi_pkg::MuBi4False,
+          clk_main_i,
+          !rst_por_ni)
+
+  `ASSERT(DAonRstAonEnTracksRstAonActive_A,
+          $fell(resets_i.rst_aon_n[DomainAonSel]) |-> ##[0:DELAY]
+          reset_en_i.aon[DomainAonSel] == prim_mubi_pkg::MuBi4True,
+          clk_aon_i,
+          !rst_por_ni)
+
+  `ASSERT(DAonRstAonEnTracksRstAonInactive_A,
+          $rose(resets_i.rst_aon_n[DomainAonSel]) |-> ##DELAY
+          !resets_i.rst_aon_n[DomainAonSel] ||
+          reset_en_i.aon[DomainAonSel] == prim_mubi_pkg::MuBi4False,
+          clk_aon_i,
+          !rst_por_ni)
+
   `ASSERT(DMainRstIoEnTracksRstIoActive_A,
           $fell(resets_i.rst_io_n[DomainMainSel]) |-> ##[0:DELAY]
           reset_en_i.io[DomainMainSel] == prim_mubi_pkg::MuBi4True,
@@ -91,6 +117,19 @@ interface rstmgr_rst_en_track_sva_if (
           $rose(resets_i.rst_io_n[DomainMainSel]) |-> ##DELAY
           !resets_i.rst_io_n[DomainMainSel] ||
           reset_en_i.io[DomainMainSel] == prim_mubi_pkg::MuBi4False,
+          clk_io_i,
+          !rst_por_ni)
+
+  `ASSERT(DAonRstIoEnTracksRstIoActive_A,
+          $fell(resets_i.rst_io_n[DomainAonSel]) |-> ##[0:DELAY]
+          reset_en_i.io[DomainAonSel] == prim_mubi_pkg::MuBi4True,
+          clk_io_i,
+          !rst_por_ni)
+
+  `ASSERT(DAonRstIoEnTracksRstIoInactive_A,
+          $rose(resets_i.rst_io_n[DomainAonSel]) |-> ##DELAY
+          !resets_i.rst_io_n[DomainAonSel] ||
+          reset_en_i.io[DomainAonSel] == prim_mubi_pkg::MuBi4False,
           clk_io_i,
           !rst_por_ni)
 

--- a/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -184,12 +184,12 @@ module rstmgr
   ////////////////////////////////////////////////////
 
   // consistency check errors
-  logic [6:0][PowerDomains-1:0] cnsty_chk_errs;
-  logic [6:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
+  logic [7:0][PowerDomains-1:0] cnsty_chk_errs;
+  logic [7:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
 
   // consistency sparse fsm errors
-  logic [6:0][PowerDomains-1:0] fsm_errs;
-  logic [6:0][PowerDomains-1:0] shadow_fsm_errs;
+  logic [7:0][PowerDomains-1:0] fsm_errs;
+  logic [7:0][PowerDomains-1:0] shadow_fsm_errs;
 
   assign hw2reg.err_code.reg_intg_err.d  = 1'b1;
   assign hw2reg.err_code.reg_intg_err.de = reg_intg_err;
@@ -370,7 +370,7 @@ module rstmgr
     .clk_i,
     .rst_ni,
     .leaf_clk_i(clk_main_i),
-    .parent_rst_ni(rst_sys_src_n[DomainMainSel]),
+    .parent_rst_ni(rst_lc_src_n[DomainMainSel]),
     .sw_rst_req_ni(1'b1),
     .scan_rst_ni,
     .scanmode_i,
@@ -404,7 +404,7 @@ module rstmgr
     .clk_i,
     .rst_ni,
     .leaf_clk_i(clk_io_i),
-    .parent_rst_ni(rst_sys_src_n[DomainMainSel]),
+    .parent_rst_ni(rst_lc_src_n[DomainMainSel]),
     .sw_rst_req_ni(1'b1),
     .scan_rst_ni,
     .scanmode_i,
@@ -438,7 +438,7 @@ module rstmgr
     .clk_i,
     .rst_ni,
     .leaf_clk_i(clk_io_i),
-    .parent_rst_ni(rst_sys_src_n[DomainMainSel]),
+    .parent_rst_ni(rst_lc_src_n[DomainMainSel]),
     .sw_rst_req_ni(reg2hw.sw_rst_ctrl_n[SPI_DEVICE].q),
     .scan_rst_ni,
     .scanmode_i,
@@ -472,7 +472,7 @@ module rstmgr
     .clk_i,
     .rst_ni,
     .leaf_clk_i(clk_io_i),
-    .parent_rst_ni(rst_sys_src_n[DomainMainSel]),
+    .parent_rst_ni(rst_lc_src_n[DomainMainSel]),
     .sw_rst_req_ni(reg2hw.sw_rst_ctrl_n[SPI_HOST].q),
     .scan_rst_ni,
     .scanmode_i,
@@ -506,7 +506,7 @@ module rstmgr
     .clk_i,
     .rst_ni,
     .leaf_clk_i(clk_io_i),
-    .parent_rst_ni(rst_sys_src_n[DomainMainSel]),
+    .parent_rst_ni(rst_lc_src_n[DomainMainSel]),
     .sw_rst_req_ni(reg2hw.sw_rst_ctrl_n[I2C].q),
     .scan_rst_ni,
     .scanmode_i,
@@ -524,6 +524,40 @@ module rstmgr
   end
   assign shadow_cnsty_chk_errs[6] = '0;
   assign shadow_fsm_errs[6] = '0;
+
+  // Generating resets for debug
+  // Power Domains: ['Main']
+  // Shadowed: False
+  assign resets_o.rst_debug_n[DomainAonSel] = '0;
+  assign cnsty_chk_errs[7][DomainAonSel] = '0;
+  assign fsm_errs[7][DomainAonSel] = '0;
+  assign rst_en_o.debug[DomainAonSel] = MuBi4True;
+  rstmgr_leaf_rst #(
+    .SecCheck(SecCheck),
+    .SecMaxSyncDelay(SecMaxSyncDelay),
+    .SwRstReq(1'b0)
+  ) u_dmain_debug (
+    .clk_i,
+    .rst_ni,
+    .leaf_clk_i(clk_main_i),
+    .parent_rst_ni(rst_sys_src_n[DomainMainSel]),
+    .sw_rst_req_ni(1'b1),
+    .scan_rst_ni,
+    .scanmode_i,
+    .rst_en_o(rst_en_o.debug[DomainMainSel]),
+    .leaf_rst_o(resets_o.rst_debug_n[DomainMainSel]),
+    .err_o(cnsty_chk_errs[7][DomainMainSel]),
+    .fsm_err_o(fsm_errs[7][DomainMainSel])
+  );
+
+  if (SecCheck) begin : gen_dmain_debug_assert
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
+    DMainDebugFsmCheck_A,
+    u_dmain_debug.gen_rst_chk.u_rst_chk.u_state_regs,
+    alert_tx_o[0])
+  end
+  assign shadow_cnsty_chk_errs[7] = '0;
+  assign shadow_fsm_errs[7] = '0;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -184,12 +184,12 @@ module rstmgr
   ////////////////////////////////////////////////////
 
   // consistency check errors
-  logic [7:0][PowerDomains-1:0] cnsty_chk_errs;
-  logic [7:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
+  logic [8:0][PowerDomains-1:0] cnsty_chk_errs;
+  logic [8:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
 
   // consistency sparse fsm errors
-  logic [7:0][PowerDomains-1:0] fsm_errs;
-  logic [7:0][PowerDomains-1:0] shadow_fsm_errs;
+  logic [8:0][PowerDomains-1:0] fsm_errs;
+  logic [8:0][PowerDomains-1:0] shadow_fsm_errs;
 
   assign hw2reg.err_code.reg_intg_err.d  = 1'b1;
   assign hw2reg.err_code.reg_intg_err.de = reg_intg_err;
@@ -389,12 +389,46 @@ module rstmgr
   assign shadow_cnsty_chk_errs[2] = '0;
   assign shadow_fsm_errs[2] = '0;
 
+  // Generating resets for aon
+  // Power Domains: ['Aon']
+  // Shadowed: False
+  rstmgr_leaf_rst #(
+    .SecCheck(SecCheck),
+    .SecMaxSyncDelay(SecMaxSyncDelay),
+    .SwRstReq(1'b0)
+  ) u_daon_aon (
+    .clk_i,
+    .rst_ni,
+    .leaf_clk_i(clk_aon_i),
+    .parent_rst_ni(rst_lc_src_n[DomainAonSel]),
+    .sw_rst_req_ni(1'b1),
+    .scan_rst_ni,
+    .scanmode_i,
+    .rst_en_o(rst_en_o.aon[DomainAonSel]),
+    .leaf_rst_o(resets_o.rst_aon_n[DomainAonSel]),
+    .err_o(cnsty_chk_errs[3][DomainAonSel]),
+    .fsm_err_o(fsm_errs[3][DomainAonSel])
+  );
+
+  if (SecCheck) begin : gen_daon_aon_assert
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
+    DAonAonFsmCheck_A,
+    u_daon_aon.gen_rst_chk.u_rst_chk.u_state_regs,
+    alert_tx_o[0])
+  end
+  assign resets_o.rst_aon_n[DomainMainSel] = '0;
+  assign cnsty_chk_errs[3][DomainMainSel] = '0;
+  assign fsm_errs[3][DomainMainSel] = '0;
+  assign rst_en_o.aon[DomainMainSel] = MuBi4True;
+  assign shadow_cnsty_chk_errs[3] = '0;
+  assign shadow_fsm_errs[3] = '0;
+
   // Generating resets for io
   // Power Domains: ['Main']
   // Shadowed: False
   assign resets_o.rst_io_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[3][DomainAonSel] = '0;
-  assign fsm_errs[3][DomainAonSel] = '0;
+  assign cnsty_chk_errs[4][DomainAonSel] = '0;
+  assign fsm_errs[4][DomainAonSel] = '0;
   assign rst_en_o.io[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -410,8 +444,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.io[DomainMainSel]),
     .leaf_rst_o(resets_o.rst_io_n[DomainMainSel]),
-    .err_o(cnsty_chk_errs[3][DomainMainSel]),
-    .fsm_err_o(fsm_errs[3][DomainMainSel])
+    .err_o(cnsty_chk_errs[4][DomainMainSel]),
+    .fsm_err_o(fsm_errs[4][DomainMainSel])
   );
 
   if (SecCheck) begin : gen_dmain_io_assert
@@ -420,15 +454,15 @@ module rstmgr
     u_dmain_io.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[3] = '0;
-  assign shadow_fsm_errs[3] = '0;
+  assign shadow_cnsty_chk_errs[4] = '0;
+  assign shadow_fsm_errs[4] = '0;
 
   // Generating resets for spi_device
   // Power Domains: ['Main']
   // Shadowed: False
   assign resets_o.rst_spi_device_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[4][DomainAonSel] = '0;
-  assign fsm_errs[4][DomainAonSel] = '0;
+  assign cnsty_chk_errs[5][DomainAonSel] = '0;
+  assign fsm_errs[5][DomainAonSel] = '0;
   assign rst_en_o.spi_device[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -444,8 +478,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_device[DomainMainSel]),
     .leaf_rst_o(resets_o.rst_spi_device_n[DomainMainSel]),
-    .err_o(cnsty_chk_errs[4][DomainMainSel]),
-    .fsm_err_o(fsm_errs[4][DomainMainSel])
+    .err_o(cnsty_chk_errs[5][DomainMainSel]),
+    .fsm_err_o(fsm_errs[5][DomainMainSel])
   );
 
   if (SecCheck) begin : gen_dmain_spi_device_assert
@@ -454,15 +488,15 @@ module rstmgr
     u_dmain_spi_device.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[4] = '0;
-  assign shadow_fsm_errs[4] = '0;
+  assign shadow_cnsty_chk_errs[5] = '0;
+  assign shadow_fsm_errs[5] = '0;
 
   // Generating resets for spi_host
   // Power Domains: ['Main']
   // Shadowed: False
   assign resets_o.rst_spi_host_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[5][DomainAonSel] = '0;
-  assign fsm_errs[5][DomainAonSel] = '0;
+  assign cnsty_chk_errs[6][DomainAonSel] = '0;
+  assign fsm_errs[6][DomainAonSel] = '0;
   assign rst_en_o.spi_host[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -478,8 +512,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_host[DomainMainSel]),
     .leaf_rst_o(resets_o.rst_spi_host_n[DomainMainSel]),
-    .err_o(cnsty_chk_errs[5][DomainMainSel]),
-    .fsm_err_o(fsm_errs[5][DomainMainSel])
+    .err_o(cnsty_chk_errs[6][DomainMainSel]),
+    .fsm_err_o(fsm_errs[6][DomainMainSel])
   );
 
   if (SecCheck) begin : gen_dmain_spi_host_assert
@@ -488,15 +522,15 @@ module rstmgr
     u_dmain_spi_host.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[5] = '0;
-  assign shadow_fsm_errs[5] = '0;
+  assign shadow_cnsty_chk_errs[6] = '0;
+  assign shadow_fsm_errs[6] = '0;
 
   // Generating resets for i2c
   // Power Domains: ['Main']
   // Shadowed: False
   assign resets_o.rst_i2c_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[6][DomainAonSel] = '0;
-  assign fsm_errs[6][DomainAonSel] = '0;
+  assign cnsty_chk_errs[7][DomainAonSel] = '0;
+  assign fsm_errs[7][DomainAonSel] = '0;
   assign rst_en_o.i2c[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -512,8 +546,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.i2c[DomainMainSel]),
     .leaf_rst_o(resets_o.rst_i2c_n[DomainMainSel]),
-    .err_o(cnsty_chk_errs[6][DomainMainSel]),
-    .fsm_err_o(fsm_errs[6][DomainMainSel])
+    .err_o(cnsty_chk_errs[7][DomainMainSel]),
+    .fsm_err_o(fsm_errs[7][DomainMainSel])
   );
 
   if (SecCheck) begin : gen_dmain_i2c_assert
@@ -522,15 +556,15 @@ module rstmgr
     u_dmain_i2c.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[6] = '0;
-  assign shadow_fsm_errs[6] = '0;
+  assign shadow_cnsty_chk_errs[7] = '0;
+  assign shadow_fsm_errs[7] = '0;
 
   // Generating resets for debug
   // Power Domains: ['Main']
   // Shadowed: False
   assign resets_o.rst_debug_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[7][DomainAonSel] = '0;
-  assign fsm_errs[7][DomainAonSel] = '0;
+  assign cnsty_chk_errs[8][DomainAonSel] = '0;
+  assign fsm_errs[8][DomainAonSel] = '0;
   assign rst_en_o.debug[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -546,8 +580,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.debug[DomainMainSel]),
     .leaf_rst_o(resets_o.rst_debug_n[DomainMainSel]),
-    .err_o(cnsty_chk_errs[7][DomainMainSel]),
-    .fsm_err_o(fsm_errs[7][DomainMainSel])
+    .err_o(cnsty_chk_errs[8][DomainMainSel]),
+    .fsm_err_o(fsm_errs[8][DomainMainSel])
   );
 
   if (SecCheck) begin : gen_dmain_debug_assert
@@ -556,8 +590,8 @@ module rstmgr
     u_dmain_debug.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[7] = '0;
-  assign shadow_fsm_errs[7] = '0;
+  assign shadow_cnsty_chk_errs[8] = '0;
+  assign shadow_fsm_errs[8] = '0;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
@@ -29,6 +29,7 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_spi_device_n;
     logic [PowerDomains-1:0] rst_spi_host_n;
     logic [PowerDomains-1:0] rst_i2c_n;
+    logic [PowerDomains-1:0] rst_debug_n;
   } rstmgr_out_t;
 
   // reset indication for alert handler
@@ -41,9 +42,10 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_device;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] i2c;
+    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] debug;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 8 * PowerDomains;
+  parameter int NumOutputRst = 9 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
@@ -25,6 +25,7 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_por_n;
     logic [PowerDomains-1:0] rst_por_io_n;
     logic [PowerDomains-1:0] rst_main_n;
+    logic [PowerDomains-1:0] rst_aon_n;
     logic [PowerDomains-1:0] rst_io_n;
     logic [PowerDomains-1:0] rst_spi_device_n;
     logic [PowerDomains-1:0] rst_spi_host_n;
@@ -38,6 +39,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] main;
+    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] aon;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] io;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_device;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host;
@@ -45,7 +47,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] debug;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 9 * PowerDomains;
+  parameter int NumOutputRst = 10 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_chip/rtl/top_chip_system.sv
+++ b/hw/top_chip/rtl/top_chip_system.sv
@@ -1010,7 +1010,7 @@ module top_chip_system #(
     clkmgr_clocks.clk_main_hint | clkmgr_clocks.clk_io_peri |
     (|clkmgr_cg_en) |
     (|rstmgr_resets.rst_por_n) | (|rstmgr_resets.rst_spi_device_n) | (|rstmgr_resets.rst_spi_host_n) | (|rstmgr_resets.rst_i2c_n) |
-    (|rstmgr_rst_en);
+    (|rstmgr_resets.rst_debug_n) | (|rstmgr_rst_en);
 
   // Combine response and request between crossbar and atomics wrapper.
   AXI_BUS #(

--- a/hw/top_chip/rtl/top_chip_system.sv
+++ b/hw/top_chip/rtl/top_chip_system.sv
@@ -913,16 +913,20 @@ module top_chip_system #(
     .tl_o        (tl_clkmgr_d2h),
     .scanmode_i  (prim_mubi_pkg::MuBi4False),
 
-    // Clock and reset connections.
+    // Primary module control clocks and resets.
     .clk_i            (clkmgr_clocks.clk_io_powerup),
-    .clk_main_i       (clk_i),
-    .clk_io_i         (clk_i),
-    .clk_aon_i        (clk_i),
-    .rst_shadowed_ni  (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
     .rst_ni           (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
-    .rst_aon_ni       (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
-    .rst_io_ni        (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
-    .rst_main_ni      (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
+    .rst_shadowed_ni  (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
+
+    // System source clocks and resets.
+    .clk_main_i       (clk_i),
+    .rst_main_ni      (rstmgr_resets.rst_main_n[rstmgr_pkg::DomainAonSel]),
+    .clk_io_i         (clk_i),
+    .rst_io_ni        (rstmgr_resets.rst_io_n[rstmgr_pkg::DomainAonSel]),
+    .clk_aon_i        (clk_i),
+    .rst_aon_ni       (rstmgr_resets.rst_aon_n[rstmgr_pkg::DomainAonSel]),
+
+    // Resets for derived clock generation, root clock gating and related status.
     .rst_root_ni      (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
     .rst_root_io_ni   (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
     .rst_root_main_ni (rstmgr_resets.rst_por_n[rstmgr_pkg::DomainAonSel])

--- a/hw/top_chip/rtl/top_chip_system.sv
+++ b/hw/top_chip/rtl/top_chip_system.sv
@@ -670,7 +670,7 @@ module top_chip_system #(
     .InputDelayCycles(0) // note: may not be true for all tops
   ) u_i2c (
     .clk_i  (clkmgr_clocks.clk_io_infra),
-    .rst_ni (rstmgr_resets.rst_io_n[rstmgr_pkg::DomainMainSel]),
+    .rst_ni (rstmgr_resets.rst_i2c_n[rstmgr_pkg::DomainMainSel]),
 
     .alert_rx_i (prim_alert_pkg::ALERT_RX_DEFAULT),
     .alert_tx_o ( ),
@@ -757,7 +757,7 @@ module top_chip_system #(
   // Instantiate SPI device
   spi_device u_spi_device (
     .clk_i  (clkmgr_clocks.clk_io_infra),
-    .rst_ni (rstmgr_resets.rst_io_n[rstmgr_pkg::DomainMainSel]),
+    .rst_ni (rstmgr_resets.rst_spi_device_n[rstmgr_pkg::DomainMainSel]),
 
     // Signals to xbar
     .tl_i (tl_spi_device_h2d),
@@ -809,7 +809,7 @@ module top_chip_system #(
   ) u_spi_host (
     // Clock and reset.
     .clk_i  (clkmgr_clocks.clk_io_infra),
-    .rst_ni (rstmgr_resets.rst_io_n[rstmgr_pkg::DomainMainSel]),
+    .rst_ni (rstmgr_resets.rst_spi_host_n[rstmgr_pkg::DomainMainSel]),
 
     // TileLink bus connections.
     .tl_i (tl_spi_host_h2d),
@@ -1013,8 +1013,7 @@ module top_chip_system #(
   assign unused_manager_output =
     clkmgr_clocks.clk_main_hint | clkmgr_clocks.clk_io_peri |
     (|clkmgr_cg_en) |
-    (|rstmgr_resets.rst_por_n) | (|rstmgr_resets.rst_spi_device_n) | (|rstmgr_resets.rst_spi_host_n) | (|rstmgr_resets.rst_i2c_n) |
-    (|rstmgr_resets.rst_debug_n) | (|rstmgr_rst_en);
+    (|rstmgr_resets.rst_por_n) | (|rstmgr_resets.rst_debug_n) | (|rstmgr_rst_en);
 
   // Combine response and request between crossbar and atomics wrapper.
   AXI_BUS #(

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
@@ -184,16 +184,22 @@ interface rstmgr_cascading_sva_if (
 % endfor
 
   // Controlled by rst_lc_src_n.
-  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
-                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
-  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeLcToAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
+                    resets_o.rst_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
+  `CASCADED_ASSERTS(CascadeLcToMain, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeLcToIo, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeLcToSpiDevice, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeLcToSpiHost, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeLcToI2c, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
 
   // Controlled by rst_sys_src_n.
-  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeSysToDebug, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_debug_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
 
   `undef FALL_ASSERT
   `undef RISE_ASSERTS

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
@@ -183,21 +183,17 @@ interface rstmgr_cascading_sva_if (
                     resets_o.rst_por_${clk + "_" if clk != "main" else ""}n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_${clk}_i)
 % endfor
 
+  // Controlled by rst_lc_src_n.
+  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
+                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
+  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
+
   // Controlled by rst_sys_src_n.
-  `CASCADED_ASSERTS(CascadeSysToMain_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-
-  `CASCADED_ASSERTS(CascadeSysToIO_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-
-  `CASCADED_ASSERTS(CascadeSysToSPIHost_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-
-  `CASCADED_ASSERTS(CascadeSysToSPIDevice_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-
-  `CASCADED_ASSERTS(CascadeSysToI2C_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
+  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
 
   `undef FALL_ASSERT
   `undef RISE_ASSERTS

--- a/hw/vendor/patches/lowrisc_ip/rstmgr/0002_Fix_Templates.patch
+++ b/hw/vendor/patches/lowrisc_ip/rstmgr/0002_Fix_Templates.patch
@@ -35,42 +35,6 @@ index 356807f..1670853 100644
        check_reset_info(expected_reset_info_code);
        check_alert_info_after_reset(.alert_dump(expected_alert_dump),
                                     .enable(expected_alert_enable));
-diff --git a/dv/sva/rstmgr_cascading_sva_if.sv.tpl b/dv/sva/rstmgr_cascading_sva_if.sv.tpl
-index 143d0ed..1653cb6 100644
---- a/dv/sva/rstmgr_cascading_sva_if.sv.tpl
-+++ b/dv/sva/rstmgr_cascading_sva_if.sv.tpl
-@@ -183,17 +183,21 @@ interface rstmgr_cascading_sva_if (
-                     resets_o.rst_por_${clk + "_" if clk != "main" else ""}n[rstmgr_pkg::DomainAonSel], SyncCycles, clk_${clk}_i)
- % endfor
- 
--  // Controlled by rst_lc_src_n.
--  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
--                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
--  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
--                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
--
-   // Controlled by rst_sys_src_n.
--  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
--                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
--  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
--                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
-+  `CASCADED_ASSERTS(CascadeSysToMain_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-+                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
-+
-+  `CASCADED_ASSERTS(CascadeSysToIO_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-+                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-+
-+  `CASCADED_ASSERTS(CascadeSysToSPIHost_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-+                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-+
-+  `CASCADED_ASSERTS(CascadeSysToSPIDevice_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-+                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
-+
-+  `CASCADED_ASSERTS(CascadeSysToI2C_A, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
-+                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_io_i)
- 
-   `undef FALL_ASSERT
-   `undef RISE_ASSERTS
 diff --git a/dv/tb.sv.tpl b/dv/tb.sv.tpl
 index c2e8ce4..49dbb57 100644
 --- a/dv/tb.sv.tpl

--- a/hw/vendor/patches/lowrisc_ip/rstmgr/0003_Cascade_Assertion_Fix.patch
+++ b/hw/vendor/patches/lowrisc_ip/rstmgr/0003_Cascade_Assertion_Fix.patch
@@ -1,0 +1,35 @@
+diff --git a/dv/sva/rstmgr_cascading_sva_if.sv.tpl b/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+index 143d0ed5..f8853b04 100644
+--- a/dv/sva/rstmgr_cascading_sva_if.sv.tpl
++++ b/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+@@ -184,16 +184,22 @@ interface rstmgr_cascading_sva_if (
+ % endfor
+ 
+   // Controlled by rst_lc_src_n.
+-  `CASCADED_ASSERTS(CascadeLcToLcAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
+-                    resets_o.rst_lc_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
+-  `CASCADED_ASSERTS(CascadeLcToLc, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+-                    resets_o.rst_lc_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
++  `CASCADED_ASSERTS(CascadeLcToAon, rst_lc_src_n[rstmgr_pkg::DomainAonSel],
++                    resets_o.rst_aon_n[rstmgr_pkg::DomainAonSel], SysCycles, clk_aon_i)
++  `CASCADED_ASSERTS(CascadeLcToMain, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_main_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
++  `CASCADED_ASSERTS(CascadeLcToIo, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_io_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
++  `CASCADED_ASSERTS(CascadeLcToSpiDevice, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_spi_device_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
++  `CASCADED_ASSERTS(CascadeLcToSpiHost, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_spi_host_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
++  `CASCADED_ASSERTS(CascadeLcToI2c, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_i2c_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_io_i)
+ 
+   // Controlled by rst_sys_src_n.
+-  `CASCADED_ASSERTS(CascadeSysToSys, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
+-                    resets_o.rst_sys_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+-  `CASCADED_ASSERTS(CascadeLcToLcShadowed, rst_lc_src_n[rstmgr_pkg::DomainMainSel],
+-                    resets_o.rst_lc_shadowed_n[rstmgr_pkg::DomainMainSel], SysCycles, clk_main_i)
++  `CASCADED_ASSERTS(CascadeSysToDebug, rst_sys_src_n[rstmgr_pkg::DomainMainSel],
++                    resets_o.rst_debug_n[rstmgr_pkg::DomainMainSel], PeriCycles, clk_main_i)
+ 
+   `undef FALL_ASSERT
+   `undef RISE_ASSERTS

--- a/util/artefacts.py
+++ b/util/artefacts.py
@@ -58,6 +58,8 @@ COMMANDS: list[list[str]] = [
     ],
     # documentation
     ["d2", "doc/img/mocha.d2"],
+    # vendor OpenTitan before doing the IP generation because patches might change the template
+    ["util/vendor.py", "hw/vendor/lowrisc_ip.vendor.hjson"],
     # crossbar generator
     [
         "hw/vendor/lowrisc_ip/util/tlgen.py",
@@ -143,7 +145,6 @@ COMMANDS: list[list[str]] = [
     ["util/vendor.py", "hw/vendor/cva6_cheri.vendor.hjson"],
     ["util/vendor.py", "hw/vendor/hpdcache.vendor.hjson"],
     ["util/vendor.py", "hw/vendor/ethernet.vendor.hjson"],
-    ["util/vendor.py", "hw/vendor/lowrisc_ip.vendor.hjson"],
     ["util/vendor.py", "hw/vendor/pulp_axi.vendor.hjson"],
     ["util/vendor.py", "hw/vendor/pulp_axi_llc.vendor.hjson"],
     ["util/vendor.py", "hw/vendor/pulp_register_interface.vendor.hjson"],


### PR DESCRIPTION
This PR adds a debug domain reset under the sys reset tree, and moves existing main and IO clock resets under the LC reset tree.

General improvements to reset connections are also added.

Closes #571 
Closes https://github.com/lowRISC/mocha/issues/592