### PR TITLE
fpga runner, nix, sw: Update to `ftditool` 0.5.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,16 +49,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1780322259,
-        "narHash": "sha256-Mx5UpEs8guUhRdvaI2ua58SkO11VK57TjjQLhsAiKag=",
+        "lastModified": 1781777692,
+        "narHash": "sha256-4+bp4ZiJ0YxN5wjCDi15s4mSyuGJoj5wPKn8eKE24XY=",
         "owner": "lowRISC",
         "repo": "ftditool",
-        "rev": "feabaa5e4ae8da3bb70ab4a124fd695040368020",
+        "rev": "be6c376e5ce0f842d9d68d57562f0345f1f7d856",
         "type": "github"
       },
       "original": {
         "owner": "lowRISC",
-        "ref": "v0.4.0",
+        "ref": "v0.5.0",
         "repo": "ftditool",
         "type": "github"
       }
@@ -88,11 +88,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780410653,
-        "narHash": "sha256-GgjcPoL9ZDuasunwIP0I9JTkP2oGvoZ93Vzwbwz1ldI=",
+        "lastModified": 1780500542,
+        "narHash": "sha256-XKbtr82IfB5RXhBzWgsTnuZcS230Lq9NdFE13IM/Zi8=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "560d419c61cb216001f05db14ac64a310b64e4af",
+        "rev": "c134ded39dab6c6dc15ad4675a446269c12756ff",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778901413,
-        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
+        "lastModified": 1781585874,
+        "narHash": "sha256-T4e8kqZ/fsuqYWbcXDcr0EBLClh3VRKVV1XcL/ibf3A=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
+        "rev": "112aebcc00ecf20d48a5c08e80660a6852a4707a",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780358675,
-        "narHash": "sha256-n4jX4svZwmoWpzhz3If9wkvEYKv3WuDvprE8vi57MRY=",
+        "lastModified": 1781596548,
+        "narHash": "sha256-dhc1zBhYJbafsflK31g5+P+iot/saZPa/nUpcRkZui0=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "3a557a9e78cc5b11bc9a610f27da4bdd5599edfe",
+        "rev": "ec7b3fd86a8add8c546192ad5d66dade40d21e48",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       inputs.uv2nix.follows = "uv2nix";
     };
     ftditool = {
-      url = "github:lowRISC/ftditool?ref=v0.4.0";
+      url = "github:lowRISC/ftditool?ref=v0.5.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/sw/cmake/opensbi.cmake
+++ b/sw/cmake/opensbi.cmake
@@ -93,7 +93,7 @@ function(mocha_opensbi_with_payload_test PAYLOAD_TARGET)
 
   add_test(
       NAME ${NAME}_fpga_genesys2
-      COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py test ${NAME}/fw_payload.elf
+      COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py test -e ${NAME}/fw_payload.elf
   )
 
   set_property(TEST ${NAME}_sim_verilator PROPERTY TIMEOUT 7200)

--- a/sw/cmake/tests.cmake
+++ b/sw/cmake/tests.cmake
@@ -69,7 +69,7 @@ function(mocha_add_fpga_test)
     set(TEST ${arg_NAME}_fpga_genesys2)
     add_test(
         NAME ${TEST}
-        COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py test ${arg_NAME}
+        COMMAND ${PROJECT_SOURCE_DIR}/../util/fpga_runner.py test -e ${arg_NAME}
     )
     set_tests_properties(${TEST} PROPERTIES TIMEOUT ${arg_TIMEOUT})
 endfunction()

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -78,14 +78,35 @@ async def bootstrap(uart: serial.Serial | None) -> None:
     await set_pin(0, True)
 
 
-async def load_fpga_binary(path: Path, uart: serial.Serial | None) -> None:
-    await bootstrap(uart)
-    command = ftditool_command("bootstrap-elf")
+async def load_elf(path: Path) -> None:
+    command = ftditool_command("load-elf")
     command.append(str(path))
 
     p = await asyncio.create_subprocess_exec(*command)
     if await p.wait() != 0:
-        error("ftditool bootstrap-elf", f"exited with non-zero exit code {p.returncode}")
+        error("ftditool load-elf", f"exited with non-zero exit code {p.returncode}")
+        sys.exit(1)
+
+
+async def load_binary(path: Path, address: int) -> None:
+    command = ftditool_command("load-file")
+    command.extend([str(path), "--addr", hex(address)])
+
+    p = await asyncio.create_subprocess_exec(*command)
+    if await p.wait() != 0:
+        error("ftditool load-file", f"exited with non-zero exit code {p.returncode}")
+        sys.exit(1)
+
+
+async def exit_bootstrap() -> None:
+    """
+    Exit SPI bootstrap mode on the FPGA by sending a flash reset command to the
+    emulated flash, causing the board to jump into uploaded code.
+    """
+    command = ftditool_command("flash-reset")
+    p = await asyncio.create_subprocess_exec(*command)
+    if await p.wait() != 0:
+        error("ftditool flash-reset", f"exited with non-zero exit code {p.returncode}")
         sys.exit(1)
 
 
@@ -107,14 +128,31 @@ def find_uart(vid: int = 0x0403, pid: int = 0x6001) -> str | None:
     return None
 
 
+async def do_fpga_load(args) -> None:
+    """
+    Load all binaries and ELFs provided by the '-f' and '-e' flags onto the
+    FPGA, and then send a reset command to the emulated flash to exit SPI
+    bootstrap mode.
+    """
+    for binary, address in args.bins:
+        print(f"loading binary '{binary}' at address 0x{address:x}...")
+        await load_binary(binary, address)
+    for elf in args.elfs:
+        print(f"loading ELF '{elf}'...")
+        await load_elf(elf)
+    await exit_bootstrap()
+
+
 async def do_fpga_test(args) -> None:
     """
     Test subcommand.
-    Load the binary onto the FPGA, then poll for the test result pattern.
+    Load the binaries/ELFs onto the FPGA, then poll for the test result pattern.
     """
     if uart_tty := find_uart():
         with serial.Serial(uart_tty, BAUD_RATE, timeout=0) as uart:
-            await load_fpga_binary(args.path, uart)
+            print("bootstrapping...")
+            await bootstrap(uart)
+            await do_fpga_load(args)
             result = await poll_uart_checking_for(uart, TEST_PATTERN)
             if "PASSED" in result:
                 sys.exit(0)  # test success
@@ -127,11 +165,32 @@ async def do_fpga_test(args) -> None:
 async def do_fpga_run(args) -> None:
     """
     Run subcommand.
-    Just load the binary onto the FPGA without opening the UART,
+    Just load the binaries/ELFs onto the FPGA without opening the UART,
     so that it can remain open in a separate application (e.g screen).
     """
-    await load_fpga_binary(args.path, None)
+    print("bootstrapping...")
+    await bootstrap(None)
+    await do_fpga_load(args)
     sys.exit(0)
+
+
+class BinaryAddressPairAction(argparse.Action):
+    """
+    Parser append action for binary/address pairs for the '-f' flag.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        binary, address = values
+        try:
+            result = (Path(binary), int(address, 0))
+        except ValueError as e:
+            raise argparse.ArgumentError(self, f"Invalid address '{address}'") from e
+
+        val = getattr(namespace, self.dest, None)
+        if val is None:
+            val = []
+        val.append(result)
+        setattr(namespace, self.dest, val)
 
 
 def main() -> None:
@@ -139,25 +198,47 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command", required=True, help="Subcommands")
 
     test_help = (
-        "Load a binary on the FPGA, then poll the UART for a test result. "
+        "Load binaries/ELFs onto the FPGA, then poll the UART for a test result. "
         "Captures output from the UART."
     )
 
     test_parser = subparsers.add_parser("test", help=test_help, description=("test: " + test_help))
-    test_parser.add_argument("path", type=Path, help="Path to test ELF to test on the FPGA")
     test_parser.set_defaults(func=do_fpga_test)
 
     run_help = (
-        "Load a binary on the FPGA, then exit. This subcommand does not use the UART, "
+        "Load binaries/ELFs onto the FPGA, then exit. This subcommand does not use the UART, "
         "so that it can be kept open in a separate program (e.g screen, picocom) for "
         "interactive use."
     )
 
     run_parser = subparsers.add_parser("run", help=run_help, description=("run: " + run_help))
-    run_parser.add_argument("path", type=Path, help="Path to program ELF to load on the FPGA")
     run_parser.set_defaults(func=do_fpga_run)
 
+    for p in [test_parser, run_parser]:
+        p.add_argument(
+            "-e",
+            "--elf",
+            dest="elfs",
+            action="append",
+            metavar="elf",
+            default=[],
+            help="ELF file to load.",
+        )
+        p.add_argument(
+            "-f",
+            "--file",
+            dest="bins",
+            action=BinaryAddressPairAction,
+            nargs=2,
+            metavar=("binary", "address"),
+            default=[],
+            help="Binary file to load at given address.",
+        )
+
     args = parser.parse_args()
+    if not args.elfs and not args.bins:
+        parser.error("At least one binary or ELF file to load must be provided with '-e' or '-f'")
+
     try:
         asyncio.run(args.func(args))
     except KeyboardInterrupt:  # Suppress error traceback if interrupted by user with ctrl-c.

--- a/util/fpga_runner.py
+++ b/util/fpga_runner.py
@@ -19,29 +19,37 @@ FTDI_DEVICE_DESC = "Digilent"
 MOCHA_BOOTSTAP_PATTERN = re.compile(r"Entering SPI bootstrap")
 TEST_PATTERN = re.compile(r"TEST RESULT: (PASSED|FAILED)", re.IGNORECASE)
 
-RUNNER: str = Path(__file__).name
+RUNNER: str = Path(__file__).stem
 
 
-async def set_pin(pin: int, val: bool) -> None:
-    command = [
+def error(what: str, why: str) -> None:
+    print(f"[{RUNNER}]: {what}: {why}", file=sys.stderr)
+
+
+def ftditool_command(cmd: str) -> list[str]:
+    """Common `ftditool` commandline arguments."""
+    return [
         "ftditool",
         "--pid",
         hex(FTDI_PID),
-        "gpio-write",
-        str(pin),
-        str(int(val)),
+        cmd,
         "--ftdi",
         FTDI_DEVICE_DESC,
     ]
+
+
+async def set_pin(pin: int, val: bool) -> None:
+    command = ftditool_command("gpio-write")
+    command.extend([str(pin), str(int(val))])
 
     p = await asyncio.create_subprocess_exec(*command)
     try:
         res = await asyncio.wait_for(p.wait(), FTDITOOL_WAIT_TIME)
         if res:
-            print(f"[{RUNNER}] gpio-write command exited with non-zero exit code {p.returncode}")
+            error("ftditool gpio-write", f"exited with non-zero exit code {p.returncode}")
             sys.exit(1)
     except TimeoutError:
-        print(f"[{RUNNER}] gpio-write timed out after {FTDITOOL_WAIT_TIME} seconds")
+        error("ftditool gpio-write", f"timed out after {FTDITOOL_WAIT_TIME} seconds")
         await p.terminate()  # or maybe p.kill()
         sys.exit(1)
 
@@ -72,20 +80,12 @@ async def bootstrap(uart: serial.Serial | None) -> None:
 
 async def load_fpga_binary(path: Path, uart: serial.Serial | None) -> None:
     await bootstrap(uart)
-
-    command = [
-        "ftditool",
-        "--pid",
-        hex(FTDI_PID),
-        "bootstrap-elf",
-        str(path),
-        "--ftdi",
-        FTDI_DEVICE_DESC,
-    ]
+    command = ftditool_command("bootstrap-elf")
+    command.append(str(path))
 
     p = await asyncio.create_subprocess_exec(*command)
     if await p.wait() != 0:
-        print(f"[{RUNNER}] SPI load command exited with non-zero exit code {p.returncode}")
+        error("ftditool bootstrap-elf", f"exited with non-zero exit code {p.returncode}")
         sys.exit(1)
 
 
@@ -120,7 +120,7 @@ async def do_fpga_test(args) -> None:
                 sys.exit(0)  # test success
             sys.exit(1)
 
-    print(f"[{RUNNER}] Error: UART device not found")
+    error("test", "UART not found")
     sys.exit(1)
 
 


### PR DESCRIPTION
Update to `ftditool` version 0.5.0.

This version renames `bootstrap-elf` to `load-elf` and does not send a reset to the flash chip automatically - a new `flash-reset` command is provided to do so. This is to allow loading multiple binaries/ELFs before sending the flash reset, which we can use in CI for testing Linux with an initramfs.

The fpga_runner command line interface has been modified to take binaries and their load address with the `-f` flag, and ELF files with the `-e` flag. Usage sites in CMake have also been updated.