### PR TITLE
Add nix shell wrapper to fpga_runner

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
           pythonEnv
           ;
         llvm = lrPkgs.llvm_cheri;
+        ftditool = ftditool-cli;
       };
       ftditool-cli = inputs.ftditool.packages.${system}.default;
       cheri-toolchain = pkgs.callPackage ./nix/cheri_toolchain.nix {inherit (lrPkgs) llvm_cheri;};
@@ -145,6 +146,9 @@
         };
         bitstream-load = flake-utils.lib.mkApp {
           drv = fpga.bitstream-load;
+        };
+        fpga-runner = flake-utils.lib.mkApp {
+          drv = fpga.fpga-runner;
         };
       };
     };

--- a/nix/fpga.nix
+++ b/nix/fpga.nix
@@ -5,6 +5,7 @@
   pkgs,
   pythonEnv,
   llvm,
+  ftditool,
 }: let
   bitstream_path = "build/lowrisc_mocha_chip_mocha_genesys2_0/synth-vivado";
   bootrom_path = "build/sw/device/bootrom";
@@ -55,4 +56,15 @@ in {
       openFPGALoader -b genesys2 "$bitstream"
     '';
   };
+
+  fpga-runner = let
+    python312 = pkgs.python312.withPackages (ps: [ps.pyserial]);
+  in
+    pkgs.writeShellApplication {
+      name = "fpga-runner";
+      runtimeInputs = [python312 ftditool];
+      text = ''
+        python3 util/fpga_runner.py "$@"
+      '';
+    };
 }

--- a/nix/fpga.nix
+++ b/nix/fpga.nix
@@ -51,7 +51,8 @@ in {
     name = "bitstream-load";
     runtimeInputs = [pkgs.openfpgaloader];
     text = ''
-      openFPGALoader -b genesys2 ${bitstream_path}/lowrisc_mocha_chip_mocha_genesys2_0.bit
+      bitstream=''${1:-${bitstream_path}/lowrisc_mocha_chip_mocha_genesys2_0.bit}
+      openFPGALoader -b genesys2 "$bitstream"
     '';
   };
 }


### PR DESCRIPTION
This will be mainly be used by users testing the release artefacts.
## Usage
```sh
nix run .#bitstream-load <path/to/bitstream>
```
```sh
nix run .#fpga-runner -- test -e build/sw/device/tests/uart_smoketest_cheri
```