### PR TITLE
[hw,prim] Add Assert Known for async FIFO

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/prim/rtl/prim_fifo_async.sv
+++ b/hw/vendor/lowrisc_ip/ip/prim/rtl/prim_fifo_async.sv
@@ -295,4 +295,14 @@ module prim_fifo_async #(
   `ASSERT(GrayRptr_A, ##1 $countones(fifo_rptr_gray_q ^ $past(fifo_rptr_gray_q)) <= 1,
           clk_rd_i, !rst_rd_ni)
 
+  //////////////////////
+  // Known Assertions //
+  //////////////////////
+
+  `ASSERT_KNOWN_IF(DataKnown_A, rdata_o, rvalid_o, clk_rd_i, !rst_rd_ni)
+  `ASSERT_KNOWN(WriteDepthKnown_A, wdepth_o, clk_wr_i, !rst_wr_ni)
+  `ASSERT_KNOWN(ReadDepthKnown_A, rdepth_o, clk_rd_i, !rst_rd_ni)
+  `ASSERT_KNOWN(RvalidKnown_A, rvalid_o, clk_rd_i, !rst_rd_ni)
+  `ASSERT_KNOWN(WreadyKnown_A, wready_o, clk_wr_i, !rst_wr_ni)
+
 endmodule

--- a/hw/vendor/patches/lowrisc_ip/prim/0005_async_fifo_assert_known.patch
+++ b/hw/vendor/patches/lowrisc_ip/prim/0005_async_fifo_assert_known.patch
@@ -1,0 +1,19 @@
+diff --git a/rtl/prim_fifo_async.sv b/rtl/prim_fifo_async.sv
+index a74d3a8..86714d1 100644
+--- a/rtl/prim_fifo_async.sv
++++ b/rtl/prim_fifo_async.sv
+@@ -295,4 +295,14 @@ module prim_fifo_async #(
+   `ASSERT(GrayRptr_A, ##1 $countones(fifo_rptr_gray_q ^ $past(fifo_rptr_gray_q)) <= 1,
+           clk_rd_i, !rst_rd_ni)
+ 
++  //////////////////////
++  // Known Assertions //
++  //////////////////////
++
++  `ASSERT_KNOWN_IF(DataKnown_A, rdata_o, rvalid_o, clk_rd_i, !rst_rd_ni)
++  `ASSERT_KNOWN(WriteDepthKnown_A, wdepth_o, clk_wr_i, !rst_wr_ni)
++  `ASSERT_KNOWN(ReadDepthKnown_A, rdepth_o, clk_rd_i, !rst_rd_ni)
++  `ASSERT_KNOWN(RvalidKnown_A, rvalid_o, clk_rd_i, !rst_rd_ni)
++  `ASSERT_KNOWN(WreadyKnown_A, wready_o, clk_wr_i, !rst_wr_ni)
++
+ endmodule


### PR DESCRIPTION
This is a prerequisite for TLUL crossbar D1 sign-off. I have tested that UVM smoke test passes.

Closes #636 