### PR TITLE
[fpga] Fix ROM corruption on async reset assertion

### DIFF
--- a/hw/top_chip/rtl/chip_mocha_genesys2.sv
+++ b/hw/top_chip/rtl/chip_mocha_genesys2.sv
@@ -112,6 +112,7 @@ module chip_mocha_genesys2 #(
   logic mig_rst_n_sync_cfg;      // MIG system reset, async assertion, deassertion sync to clk_cfg
   logic mig_axi_rst_n_sync_200m; // MIG AXI reset, async assertion, deassertion sync to clk_200m
   logic rst_n_sync_50m;          // Mocha top reset, async assertion, deassertion sync to clk_50m
+  logic rst_n_sync_assert_50m;   // Mocha top synchronous reset, assertion and deassertion sync to clk_50m
   logic eth_rst_n_sync_125m;     // Ethernet MAC reset, async assertion, deassertion sync to clk_125m
 
   // Initial reset shift register
@@ -227,6 +228,19 @@ module chip_mocha_genesys2 #(
     .q_o    (eth_rst_n_sync_125m)
   );
 
+  // Additional synchroniser for generating synchronous Mocha top reset
+  // This prevents asynchronous assertion of Mocha reset which can cause
+  // timing violations for BRAM input signals and corrupt the ROM contents
+  prim_flop_2sync #(
+    .Width      (1),
+    .ResetValue ('0)
+  ) u_rst_sync_assert_50m (
+    .clk_i  (clk_50m),
+    .rst_ni (1'b1), // Intentionally not reset
+    .d_i    (rst_n_sync_50m),
+    .q_o    (rst_n_sync_assert_50m)
+  );
+
   // CHERI Mocha top
   top_chip_system #(
     .SramInitFile(SramInitFile),
@@ -234,7 +248,7 @@ module chip_mocha_genesys2 #(
   ) u_top_chip_system (
     // Clock and reset
     .clk_i    (clk_50m),
-    .rst_ni   (rst_n_sync_50m),
+    .rst_ni   (rst_n_sync_assert_50m),
 
     // GPIO
     .gpio_i    ({sd_cd, 31'(gpio_i)}),


### PR DESCRIPTION
The asynchronous Mocha reset assertion on FPGA can cause timing violations for BRAM control/address input signals, and corrupt the content of the ROM.

This PR adds a synchroniser to ensure both assertion and deassertion of the Mocha top reset on FPGA are synchronous to the clock, which prevents this issue.

Closes #639.