### PR TITLE
[dv][kmac] Integrate KMAC Block-level DV from OpenTitan

### DIFF
--- a/hw/top_chip/dv/mocha_sim_cfgs.hjson
+++ b/hw/top_chip/dv/mocha_sim_cfgs.hjson
@@ -29,6 +29,7 @@
     "{proj_root}/hw/vendor/lowrisc_ip/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
     "{proj_root}/hw/vendor/lowrisc_ip/ip/i2c/dv/i2c_sim_cfg.hjson",
+    "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
     "{proj_root}/hw/top_chip/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent.core
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
-      - lowrisc:ip:keymgr_pkg
+      - lowrisc:ip:kmac_pkg
     files:
       - key_sideload_if.sv
       - key_sideload_agent_pkg.sv

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_agent#(
-  parameter type KEY_T = keymgr_pkg::hw_key_req_t
+  parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends dv_base_agent #(
   .CFG_T          (key_sideload_agent_cfg#(KEY_T)),
   .DRIVER_T       (key_sideload_driver#(KEY_T)),

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent_cfg.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent_cfg.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_agent_cfg #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends dv_base_agent_cfg;
 
 

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent_cov.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_agent_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_agent_cov #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends dv_base_agent_cov #(key_sideload_agent_cfg#(KEY_T));
   `uvm_component_param_utils(key_sideload_agent_cov#(KEY_T))
 

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_driver#(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends dv_base_driver #(.ITEM_T(key_sideload_item#(KEY_T)),
                            .CFG_T (key_sideload_agent_cfg#(KEY_T)));
   `uvm_component_param_utils(key_sideload_driver#(KEY_T))

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_if.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_if.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 interface key_sideload_if #(
-  parameter type KEY_T = keymgr_pkg::hw_key_req_t
+  parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) (
   input logic clk_i,
   input logic rst_ni,

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_item.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_item.sv
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_item #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends uvm_sequence_item;
-  localparam int KeyWidth = ($bits(KEY_T)-1)/keymgr_pkg::Shares;
+  localparam int KeyWidth = ($bits(KEY_T)-1)/kmac_pkg::Shares;
 
   // random variables
   rand bit                valid;

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_monitor.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_monitor.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_monitor #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends dv_base_monitor #(
     .ITEM_T (key_sideload_item#(KEY_T)),
     .CFG_T  (key_sideload_agent_cfg#(KEY_T)),

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_sequencer.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/key_sideload_sequencer.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_sequencer #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 )  extends dv_base_sequencer #(
     .ITEM_T (key_sideload_item#(KEY_T)),
     .CFG_T  (key_sideload_agent_cfg#(KEY_T))

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_base_seq #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends dv_base_seq #(
     .REQ         (key_sideload_item#(KEY_T)),
     .CFG_T       (key_sideload_agent_cfg#(KEY_T)),

--- a/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class key_sideload_set_seq #(
-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+    parameter type KEY_T = kmac_pkg::hw_key_req_t
 ) extends key_sideload_base_seq #(KEY_T);
 
   `uvm_object_utils(key_sideload_set_seq#(KEY_T))

--- a/hw/vendor/lowrisc_ip/dv/sv/kmac_app_agent/kmac_app_agent.core
+++ b/hw/vendor/lowrisc_ip/dv/sv/kmac_app_agent/kmac_app_agent.core
@@ -10,7 +10,6 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
       - lowrisc:dv:push_pull_agent
-      - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:kmac_pkg
     files:
       - kmac_app_agent_pkg.sv

--- a/hw/vendor/lowrisc_ip/dv/sv/kmac_app_agent/kmac_app_agent_pkg.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/kmac_app_agent/kmac_app_agent_pkg.sv
@@ -8,7 +8,7 @@ package kmac_app_agent_pkg;
   import dv_utils_pkg::*;
   import dv_base_agent_pkg::*;
   import dv_lib_pkg::*;
-  import keymgr_pkg::*;
+  import kmac_pkg::*;
   import push_pull_agent_pkg::*;
 
   // macro includes
@@ -16,9 +16,10 @@ package kmac_app_agent_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter int KMAC_REQ_DATA_WIDTH = keymgr_pkg::KmacDataIfWidth       // data width
-                                      + keymgr_pkg::KmacDataIfWidth / 8 // data mask width
-                                      + 1;                              // bit last
+  parameter int KmacDataIfWidth = kmac_pkg::MsgWidth;
+  parameter int KMAC_REQ_DATA_WIDTH = KmacDataIfWidth       // data width
+                                      + KmacDataIfWidth / 8 // data mask width
+                                      + 1;                  // bit last
 
   `define CONNECT_DATA_WIDTH .HostDataWidth(kmac_app_agent_pkg::KMAC_REQ_DATA_WIDTH)
 

--- a/hw/vendor/lowrisc_ip/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/vendor/lowrisc_ip/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -5,8 +5,6 @@
 // verilog_lint: waive interface-name-style
 interface kmac_app_intf (input clk, input rst_n);
 
-  import keymgr_pkg::*;
-
   dv_utils_pkg::if_mode_e if_mode; // interface mode - Host or Device
 
   // interface pins used to connect with DUT
@@ -60,7 +58,7 @@ interface kmac_app_intf (input clk, input rst_n);
           clk, !rst_n || if_mode == dv_utils_pkg::Host)
 
   // Check strb is aligned to LSB, for example: if strb[1]==0, strb[$:2] should be 0 too
-  for (genvar k = 1; k < KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
+  for (genvar k = 1; k < kmac_app_agent_pkg::KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
     `ASSERT(StrbAlignLSB_A, kmac_data_req.valid && kmac_data_req.strb[k] === 0 |->
                             kmac_data_req.strb[k+1] === 0,
                             clk, !rst_n || if_mode == dv_utils_pkg::Host)

--- a/hw/vendor/lowrisc_ip/ip/kmac/data/kmac_testplan.hjson
+++ b/hw/vendor/lowrisc_ip/ip/kmac/data/kmac_testplan.hjson
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: kmac
-  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "kmac_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env.sv
@@ -25,9 +25,9 @@ class kmac_env extends cip_base_env #(
     end
 
     // get ext interfaces
-    keymgr_sideload_agent = key_sideload_agent#(keymgr_pkg::hw_key_req_t)::type_id::create(
+    keymgr_sideload_agent = key_sideload_agent#(kmac_pkg::hw_key_req_t)::type_id::create(
       "keymgr_sideload_agent", this);
-    uvm_config_db#(key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t))::set(
+    uvm_config_db#(key_sideload_agent_cfg#(kmac_pkg::hw_key_req_t))::set(
       this, "keymgr_sideload_agent*", "cfg", cfg.keymgr_sideload_agent_cfg);
 
     // config kmac virtual interface

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -61,7 +61,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
       m_kmac_app_agent_cfg[i] = kmac_app_agent_cfg::type_id::create(name);
       m_kmac_app_agent_cfg[i].if_mode = dv_utils_pkg::Host;
     end
-    keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t)::type_id
+    keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(kmac_pkg::hw_key_req_t)::type_id
                                 ::create("keymgr_sideload_agent_cfg");
     void'($value$plusargs("enable_masking=%0d", enable_masking));
     void'($value$plusargs("sw_key_masked=%0d", sw_key_masked));

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env_cov.sv
@@ -125,7 +125,7 @@ endgroup
 class app_cg_wrap;
   // done signal is sent while Keccak rounds are running
   covergroup app_cg(string name) with function sample(bit single_beat,
-                                                      bit [keymgr_pkg::KmacDataIfWidth/8-1:0] strb,
+                                                      bit [kmac_pkg::MsgWidth/8-1:0] strb,
                                                       bit err,
                                                       bit is_done,
                                                       bit in_keccak);
@@ -177,11 +177,11 @@ class app_cg_wrap;
 
   function new(string name = "app_cg");
     app_cg = new(name);
-    app_cfg_reg_cg = new(name);
+    app_cfg_reg_cg = new({name, "_cfg_reg"});
   endfunction
 
   function void app_sample(bit single_beat,
-                           bit [keymgr_pkg::KmacDataIfWidth/8-1:0] strb,
+                           bit [kmac_pkg::MsgWidth/8-1:0] strb,
                            bit err,
                            bit is_done,
                            bit in_keccak);

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -19,7 +19,6 @@ package kmac_env_pkg;
   import kmac_app_agent_pkg::*;
   import kmac_ral_pkg::*;
   import kmac_pkg::*;
-  import keymgr_pkg::*;
   import key_sideload_agent_pkg::*;
   import sec_cm_pkg::*;
 

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -110,8 +110,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
   // key length enum
   key_len_e key_len;
 
-  bit [keymgr_pkg::KmacDataIfWidth-1:0]   kmac_app_block_data;
-  bit [keymgr_pkg::KmacDataIfWidth/8-1:0] kmac_app_block_strb;
+  bit [kmac_pkg::MsgWidth-1:0]   kmac_app_block_data;
+  bit [kmac_pkg::MsgWidth/8-1:0] kmac_app_block_strb;
   int kmac_app_block_strb_size = 0;
   bit kmac_app_last;
 
@@ -263,13 +263,13 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
             // Once valid sideload keys have been seen, update scoreboard state.
             //
-            // Note: max size of sideloaded key is keymgr_pkg::KeyWidth
+            // Note: max size of sideloaded key is kmac_pkg::KeyWidth
 
             sideload_key = cfg.keymgr_sideload_agent_cfg.vif.sideload_key;
 
             `uvm_info(`gfn, $sformatf("detected valid sideload_key: %0p", sideload_key), UVM_HIGH)
 
-            for (int i = 0; i < keymgr_pkg::KeyWidth / 32; i++) begin
+            for (int i = 0; i < kmac_pkg::KeyWidth / 32; i++) begin
               keymgr_keys[0][i] = sideload_key.key[0][i*32 +: 32];
               keymgr_keys[1][i] = sideload_key.key[1][i*32 +: 32];
             end
@@ -287,12 +287,12 @@ class kmac_scoreboard extends cip_base_scoreboard #(
   // Get sideload keys, pack and return the keys.
   virtual function bit [KMAC_NUM_SHARES-1:0][KMAC_NUM_KEYS_PER_SHARE-1:0][31:0] get_keymgr_keys();
     bit [KMAC_NUM_SHARES-1:0][KMAC_NUM_KEYS_PER_SHARE-1:0][31:0] keymgr_keys;
-    keymgr_pkg::hw_key_req_t sideload_key;
+    kmac_pkg::hw_key_req_t sideload_key;
 
     if (cfg.keymgr_sideload_agent_cfg.vif.sideload_key.valid) begin
       sideload_key = cfg.keymgr_sideload_agent_cfg.vif.sideload_key;
       `uvm_info(`gfn, $sformatf("get valid sideload_key: %0p", sideload_key), UVM_HIGH)
-      for (int i = 0; i < keymgr_pkg::KeyWidth / 32; i++) begin
+      for (int i = 0; i < kmac_pkg::KeyWidth / 32; i++) begin
         keymgr_keys[0][i] = sideload_key.key[0][i*32 +: 32];
         keymgr_keys[1][i] = sideload_key.key[1][i*32 +: 32];
       end
@@ -561,7 +561,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                 // sample coverage
                 if (cfg.en_cov) begin
                   cov.app_cg_wrappers[app_mode].app_sample(
-                    kmac_app_rsp.byte_data_q.size() <= keymgr_pkg::KmacDataIfWidth/8,
+                    kmac_app_rsp.byte_data_q.size() <= kmac_pkg::MsgWidth/8,
                     '0,
                     kmac_app_rsp.rsp_error,
                     1,

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -18,10 +18,12 @@ class kmac_common_vseq extends kmac_base_vseq;
     if (common_seq_type inside {"shadow_reg_errors", "shadow_reg_errors_with_csr_rw"}) begin
       csr_excl_item csr_excl = ral.get_excl_item();
       // Shadow storage fatal error might cause req to drop without ack.
+`ifdef KMAC_MASKING
       $assertoff(0,
       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
       $assertoff(0,
       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
+`endif
       $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
       $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
     end

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -8,8 +8,10 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
   `uvm_object_new
 
   virtual function void disable_asserts();
+`ifdef KMAC_MASKING
     $assertoff(0,
       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
+`endif
     $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
     $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
   endfunction

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -103,8 +103,8 @@ class kmac_smoke_vseq extends kmac_base_vseq;
   // Do a full message hash, repeated num_trans times
   task body();
 
-    logic [keymgr_pkg::KeyWidth-1:0] sideload_share0;
-    logic [keymgr_pkg::KeyWidth-1:0] sideload_share1;
+    logic [kmac_pkg::KeyWidth-1:0] sideload_share0;
+    logic [kmac_pkg::KeyWidth-1:0] sideload_share1;
     key_sideload_set_seq sideload_seq;
 
     `uvm_info(`gfn, $sformatf("Starting %0d message hashes", num_trans), UVM_LOW)

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -63,7 +63,7 @@
   build_modes: [
     {
       name: enable_mask_mode
-      build_opts: ["+define+EN_MASKING=1", "+define+SW_KEY_MASKED=0"]
+      build_opts: ["+define+EN_MASKING=1", "+define+SW_KEY_MASKED=0", "+define+KMAC_MASKING"]
       run_opts: ["+enable_masking=1", "+sw_key_masked=0"]
     }
     {

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -12,29 +12,29 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:kmac_sim:0.1
 
   // Testplan hjson file
-  testplan: "{proj_root}/hw/ip/kmac/data/kmac_testplan.hjson"
+  testplan: "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/data/kmac_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
-  ral_spec: "{proj_root}/hw/ip/kmac/data/kmac.hjson"
+  ral_spec: "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/data/kmac.hjson"
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["kmac_bind",
@@ -56,7 +56,7 @@
     }
     {
       name: rel_path
-      value: "hw/ip/{name}_{variant}/dv"
+      value: "hw/vendor/lowrisc_ip/ip/{name}_{variant}/dv"
     }
   ]
 

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_masked_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_masked_sim_cfg.hjson
@@ -8,11 +8,11 @@
   variant: masked
 
   // Import additional common sim cfg files.
-  import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
 
   // Enable this build mode for all tests
   en_build_modes: ["enable_mask_mode"]
 
   // exclusion files
-  vcs_cov_excl_files: ["{proj_root}/hw/ip/kmac/dv/cov/kmac_masked_terminal_st_excl.el"]
+  vcs_cov_excl_files: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/cov/kmac_masked_terminal_st_excl.el"]
 }

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson
@@ -8,12 +8,12 @@
   variant: unmasked
 
   // Import additional common sim cfg files.
-  import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
+  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
 
   // Enable this build mode for all tests
   en_build_modes: ["disable_mask_mode"]
 
   // exclusion files
-  vcs_cov_excl_files: ["{proj_root}/hw/ip/kmac/dv/cov/kmac_unmasked_terminal_st_excl.el",
-                       "{proj_root}/hw/ip/kmac/dv/cov/kmac_unmasked_cov_excl.el"]
+  vcs_cov_excl_files: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/cov/kmac_unmasked_terminal_st_excl.el",
+                       "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/cov/kmac_unmasked_cov_excl.el"]
 }

--- a/hw/vendor/lowrisc_ip/ip/kmac/dv/tb.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/dv/tb.sv
@@ -17,7 +17,7 @@ module tb;
   wire clk, rst_n, rst_shadowed_n;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   // keymgr/kmac sideload wires
-  keymgr_pkg::hw_key_req_t kmac_sideload_key;
+  kmac_pkg::hw_key_req_t kmac_sideload_key;
   // kmac_app interfaces
   kmac_pkg::app_req_t [NUM_APP_INTF-1:0] app_req;
   kmac_pkg::app_rsp_t [NUM_APP_INTF-1:0] app_rsp;

--- a/hw/vendor/patches/lowrisc_ip/dv_sv/0002-kmac_dv_agents_drop_keymgr_pkg.patch
+++ b/hw/vendor/patches/lowrisc_ip/dv_sv/0002-kmac_dv_agents_drop_keymgr_pkg.patch
@@ -1,0 +1,207 @@
+diff --git a/key_sideload_agent/key_sideload_agent.core b/key_sideload_agent/key_sideload_agent.core
+index 72a73045..45332fa9 100644
+--- a/key_sideload_agent/key_sideload_agent.core
++++ b/key_sideload_agent/key_sideload_agent.core
+@@ -9,7 +9,7 @@ filesets:
+     depend:
+       - lowrisc:dv:dv_utils
+       - lowrisc:dv:dv_lib
+-      - lowrisc:ip:keymgr_pkg
++      - lowrisc:ip:kmac_pkg
+     files:
+       - key_sideload_if.sv
+       - key_sideload_agent_pkg.sv
+diff --git a/key_sideload_agent/key_sideload_agent.sv b/key_sideload_agent/key_sideload_agent.sv
+index 1f6e3c80..b9e35257 100644
+--- a/key_sideload_agent/key_sideload_agent.sv
++++ b/key_sideload_agent/key_sideload_agent.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_agent#(
+-  parameter type KEY_T = keymgr_pkg::hw_key_req_t
++  parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends dv_base_agent #(
+   .CFG_T          (key_sideload_agent_cfg#(KEY_T)),
+   .DRIVER_T       (key_sideload_driver#(KEY_T)),
+diff --git a/key_sideload_agent/key_sideload_agent_cfg.sv b/key_sideload_agent/key_sideload_agent_cfg.sv
+index 9726e0c9..3423a21b 100644
+--- a/key_sideload_agent/key_sideload_agent_cfg.sv
++++ b/key_sideload_agent/key_sideload_agent_cfg.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_agent_cfg #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends dv_base_agent_cfg;
+ 
+ 
+diff --git a/key_sideload_agent/key_sideload_agent_cov.sv b/key_sideload_agent/key_sideload_agent_cov.sv
+index 32ec149e..c3a50e77 100644
+--- a/key_sideload_agent/key_sideload_agent_cov.sv
++++ b/key_sideload_agent/key_sideload_agent_cov.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_agent_cov #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends dv_base_agent_cov #(key_sideload_agent_cfg#(KEY_T));
+   `uvm_component_param_utils(key_sideload_agent_cov#(KEY_T))
+ 
+diff --git a/key_sideload_agent/key_sideload_driver.sv b/key_sideload_agent/key_sideload_driver.sv
+index 2ffb699a..4df961ac 100644
+--- a/key_sideload_agent/key_sideload_driver.sv
++++ b/key_sideload_agent/key_sideload_driver.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_driver#(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends dv_base_driver #(.ITEM_T(key_sideload_item#(KEY_T)),
+                            .CFG_T (key_sideload_agent_cfg#(KEY_T)));
+   `uvm_component_param_utils(key_sideload_driver#(KEY_T))
+diff --git a/key_sideload_agent/key_sideload_if.sv b/key_sideload_agent/key_sideload_if.sv
+index 1f8b521e..31281c1b 100644
+--- a/key_sideload_agent/key_sideload_if.sv
++++ b/key_sideload_agent/key_sideload_if.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ interface key_sideload_if #(
+-  parameter type KEY_T = keymgr_pkg::hw_key_req_t
++  parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) (
+   input logic clk_i,
+   input logic rst_ni,
+diff --git a/key_sideload_agent/key_sideload_item.sv b/key_sideload_agent/key_sideload_item.sv
+index 7754a65c..961d6863 100644
+--- a/key_sideload_agent/key_sideload_item.sv
++++ b/key_sideload_agent/key_sideload_item.sv
+@@ -3,9 +3,9 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_item #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends uvm_sequence_item;
+-  localparam int KeyWidth = ($bits(KEY_T)-1)/keymgr_pkg::Shares;
++  localparam int KeyWidth = ($bits(KEY_T)-1)/kmac_pkg::Shares;
+ 
+   // random variables
+   rand bit                valid;
+diff --git a/key_sideload_agent/key_sideload_monitor.sv b/key_sideload_agent/key_sideload_monitor.sv
+index d5856895..a025b4fe 100644
+--- a/key_sideload_agent/key_sideload_monitor.sv
++++ b/key_sideload_agent/key_sideload_monitor.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_monitor #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends dv_base_monitor #(
+     .ITEM_T (key_sideload_item#(KEY_T)),
+     .CFG_T  (key_sideload_agent_cfg#(KEY_T)),
+diff --git a/key_sideload_agent/key_sideload_sequencer.sv b/key_sideload_agent/key_sideload_sequencer.sv
+index a9412175..4e37dc4d 100644
+--- a/key_sideload_agent/key_sideload_sequencer.sv
++++ b/key_sideload_agent/key_sideload_sequencer.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_sequencer #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ )  extends dv_base_sequencer #(
+     .ITEM_T (key_sideload_item#(KEY_T)),
+     .CFG_T  (key_sideload_agent_cfg#(KEY_T))
+diff --git a/key_sideload_agent/seq_lib/key_sideload_base_seq.sv b/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
+index 60def448..147c0f74 100644
+--- a/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
++++ b/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_base_seq #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends dv_base_seq #(
+     .REQ         (key_sideload_item#(KEY_T)),
+     .CFG_T       (key_sideload_agent_cfg#(KEY_T)),
+diff --git a/key_sideload_agent/seq_lib/key_sideload_set_seq.sv b/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
+index b25bfb25..79857b60 100644
+--- a/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
++++ b/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
+@@ -3,7 +3,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ class key_sideload_set_seq #(
+-    parameter type KEY_T = keymgr_pkg::hw_key_req_t
++    parameter type KEY_T = kmac_pkg::hw_key_req_t
+ ) extends key_sideload_base_seq #(KEY_T);
+ 
+   `uvm_object_utils(key_sideload_set_seq#(KEY_T))
+diff --git a/kmac_app_agent/kmac_app_agent.core b/kmac_app_agent/kmac_app_agent.core
+index 79527ccb..acaf70c5 100644
+--- a/kmac_app_agent/kmac_app_agent.core
++++ b/kmac_app_agent/kmac_app_agent.core
+@@ -10,7 +10,6 @@ filesets:
+       - lowrisc:dv:dv_utils
+       - lowrisc:dv:dv_lib
+       - lowrisc:dv:push_pull_agent
+-      - lowrisc:ip:keymgr_pkg
+       - lowrisc:ip:kmac_pkg
+     files:
+       - kmac_app_agent_pkg.sv
+diff --git a/kmac_app_agent/kmac_app_agent_pkg.sv b/kmac_app_agent/kmac_app_agent_pkg.sv
+index 6af1f15d..4da79b45 100644
+--- a/kmac_app_agent/kmac_app_agent_pkg.sv
++++ b/kmac_app_agent/kmac_app_agent_pkg.sv
+@@ -8,7 +8,7 @@ package kmac_app_agent_pkg;
+   import dv_utils_pkg::*;
+   import dv_base_agent_pkg::*;
+   import dv_lib_pkg::*;
+-  import keymgr_pkg::*;
++  import kmac_pkg::*;
+   import push_pull_agent_pkg::*;
+ 
+   // macro includes
+@@ -16,9 +16,10 @@ package kmac_app_agent_pkg;
+   `include "dv_macros.svh"
+ 
+   // parameters
+-  parameter int KMAC_REQ_DATA_WIDTH = keymgr_pkg::KmacDataIfWidth       // data width
+-                                      + keymgr_pkg::KmacDataIfWidth / 8 // data mask width
+-                                      + 1;                              // bit last
++  parameter int KmacDataIfWidth = kmac_pkg::MsgWidth;
++  parameter int KMAC_REQ_DATA_WIDTH = KmacDataIfWidth       // data width
++                                      + KmacDataIfWidth / 8 // data mask width
++                                      + 1;                  // bit last
+ 
+   `define CONNECT_DATA_WIDTH .HostDataWidth(kmac_app_agent_pkg::KMAC_REQ_DATA_WIDTH)
+ 
+diff --git a/kmac_app_agent/kmac_app_intf.sv b/kmac_app_agent/kmac_app_intf.sv
+index 8fe2c411..b5c926cb 100644
+--- a/kmac_app_agent/kmac_app_intf.sv
++++ b/kmac_app_agent/kmac_app_intf.sv
+@@ -5,8 +5,6 @@
+ // verilog_lint: waive interface-name-style
+ interface kmac_app_intf (input clk, input rst_n);
+ 
+-  import keymgr_pkg::*;
+-
+   dv_utils_pkg::if_mode_e if_mode; // interface mode - Host or Device
+ 
+   // interface pins used to connect with DUT
+@@ -60,7 +58,7 @@ interface kmac_app_intf (input clk, input rst_n);
+           clk, !rst_n || if_mode == dv_utils_pkg::Host)
+ 
+   // Check strb is aligned to LSB, for example: if strb[1]==0, strb[$:2] should be 0 too
+-  for (genvar k = 1; k < KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
++  for (genvar k = 1; k < kmac_app_agent_pkg::KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
+     `ASSERT(StrbAlignLSB_A, kmac_data_req.valid && kmac_data_req.strb[k] === 0 |->
+                             kmac_data_req.strb[k+1] === 0,
+                             clk, !rst_n || if_mode == dv_utils_pkg::Host)

--- a/hw/vendor/patches/lowrisc_ip/kmac/0002-Fix-DV-Paths.patch
+++ b/hw/vendor/patches/lowrisc_ip/kmac/0002-Fix-DV-Paths.patch
@@ -1,0 +1,118 @@
+diff --git a/data/kmac_testplan.hjson b/data/kmac_testplan.hjson
+index 2a28bf54..f9b33bbf 100644
+--- a/data/kmac_testplan.hjson
++++ b/data/kmac_testplan.hjson
+@@ -3,13 +3,13 @@
+ // SPDX-License-Identifier: Apache-2.0
+ {
+   name: kmac
+-  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
++  import_testplans: ["hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/csr_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/mem_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
++                     "hw/vendor/lowrisc_ip/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                      "kmac_sec_cm_testplan.hjson"]
+   testpoints: [
+     {
+diff --git a/dv/kmac_base_sim_cfg.hjson b/dv/kmac_base_sim_cfg.hjson
+index 98cdb52a..7ffdffb7 100644
+--- a/dv/kmac_base_sim_cfg.hjson
++++ b/dv/kmac_base_sim_cfg.hjson
+@@ -12,29 +12,29 @@
+   tb: tb
+ 
+   // Simulator used to sign off this block
+-  tool: vcs
++  tool: xcelium
+ 
+   // Fusesoc core file used for building the file list.
+   fusesoc_core: lowrisc:dv:kmac_sim:0.1
+ 
+   // Testplan hjson file
+-  testplan: "{proj_root}/hw/ip/kmac/data/kmac_testplan.hjson"
++  testplan: "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/data/kmac_testplan.hjson"
+ 
+   // RAL spec - used to generate the RAL model.
+-  ral_spec: "{proj_root}/hw/ip/kmac/data/kmac.hjson"
++  ral_spec: "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/data/kmac.hjson"
+ 
+   // Import additional common sim cfg files.
+   import_cfgs: [// Project wide common sim cfg file
+-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson",
+                 // Common CIP test lists
+-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",
++                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/stress_tests.hjson"]
+ 
+   // Add additional tops for simulation.
+   sim_tops: ["kmac_bind",
+@@ -56,7 +56,7 @@
+     }
+     {
+       name: rel_path
+-      value: "hw/ip/{name}_{variant}/dv"
++      value: "hw/vendor/lowrisc_ip/ip/{name}_{variant}/dv"
+     }
+   ]
+ 
+diff --git a/dv/kmac_masked_sim_cfg.hjson b/dv/kmac_masked_sim_cfg.hjson
+index d339bb09..45e2b019 100644
+--- a/dv/kmac_masked_sim_cfg.hjson
++++ b/dv/kmac_masked_sim_cfg.hjson
+@@ -8,11 +8,11 @@
+   variant: masked
+ 
+   // Import additional common sim cfg files.
+-  import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
++  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
+ 
+   // Enable this build mode for all tests
+   en_build_modes: ["enable_mask_mode"]
+ 
+   // exclusion files
+-  vcs_cov_excl_files: ["{proj_root}/hw/ip/kmac/dv/cov/kmac_masked_terminal_st_excl.el"]
++  vcs_cov_excl_files: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/cov/kmac_masked_terminal_st_excl.el"]
+ }
+diff --git a/dv/kmac_unmasked_sim_cfg.hjson b/dv/kmac_unmasked_sim_cfg.hjson
+index 8b68da19..fba0750a 100644
+--- a/dv/kmac_unmasked_sim_cfg.hjson
++++ b/dv/kmac_unmasked_sim_cfg.hjson
+@@ -8,12 +8,12 @@
+   variant: unmasked
+ 
+   // Import additional common sim cfg files.
+-  import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
++  import_cfgs: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
+ 
+   // Enable this build mode for all tests
+   en_build_modes: ["disable_mask_mode"]
+ 
+   // exclusion files
+-  vcs_cov_excl_files: ["{proj_root}/hw/ip/kmac/dv/cov/kmac_unmasked_terminal_st_excl.el",
+-                       "{proj_root}/hw/ip/kmac/dv/cov/kmac_unmasked_cov_excl.el"]
++  vcs_cov_excl_files: ["{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/cov/kmac_unmasked_terminal_st_excl.el",
++                       "{proj_root}/hw/vendor/lowrisc_ip/ip/kmac/dv/cov/kmac_unmasked_cov_excl.el"]
+ }

--- a/hw/vendor/patches/lowrisc_ip/kmac/0003-kmac-dv-env-fixes.patch
+++ b/hw/vendor/patches/lowrisc_ip/kmac/0003-kmac-dv-env-fixes.patch
@@ -1,0 +1,151 @@
+diff --git a/dv/env/kmac_env.sv b/dv/env/kmac_env.sv
+index 93c5c02c..c78784b8 100644
+--- a/dv/env/kmac_env.sv
++++ b/dv/env/kmac_env.sv
+@@ -25,9 +25,9 @@ class kmac_env extends cip_base_env #(
+     end
+ 
+     // get ext interfaces
+-    keymgr_sideload_agent = key_sideload_agent#(keymgr_pkg::hw_key_req_t)::type_id::create(
++    keymgr_sideload_agent = key_sideload_agent#(kmac_pkg::hw_key_req_t)::type_id::create(
+       "keymgr_sideload_agent", this);
+-    uvm_config_db#(key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t))::set(
++    uvm_config_db#(key_sideload_agent_cfg#(kmac_pkg::hw_key_req_t))::set(
+       this, "keymgr_sideload_agent*", "cfg", cfg.keymgr_sideload_agent_cfg);
+ 
+     // config kmac virtual interface
+diff --git a/dv/env/kmac_env_cfg.sv b/dv/env/kmac_env_cfg.sv
+index efbb3905..bbd7bbba 100644
+--- a/dv/env/kmac_env_cfg.sv
++++ b/dv/env/kmac_env_cfg.sv
+@@ -61,7 +61,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
+       m_kmac_app_agent_cfg[i] = kmac_app_agent_cfg::type_id::create(name);
+       m_kmac_app_agent_cfg[i].if_mode = dv_utils_pkg::Host;
+     end
+-    keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t)::type_id
++    keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(kmac_pkg::hw_key_req_t)::type_id
+                                 ::create("keymgr_sideload_agent_cfg");
+     void'($value$plusargs("enable_masking=%0d", enable_masking));
+     void'($value$plusargs("sw_key_masked=%0d", sw_key_masked));
+diff --git a/dv/env/kmac_env_cov.sv b/dv/env/kmac_env_cov.sv
+index 18206d81..6b1897fc 100644
+--- a/dv/env/kmac_env_cov.sv
++++ b/dv/env/kmac_env_cov.sv
+@@ -125,7 +125,7 @@ endgroup
+ class app_cg_wrap;
+   // done signal is sent while Keccak rounds are running
+   covergroup app_cg(string name) with function sample(bit single_beat,
+-                                                      bit [keymgr_pkg::KmacDataIfWidth/8-1:0] strb,
++                                                      bit [kmac_pkg::MsgWidth/8-1:0] strb,
+                                                       bit err,
+                                                       bit is_done,
+                                                       bit in_keccak);
+@@ -177,11 +177,11 @@ class app_cg_wrap;
+ 
+   function new(string name = "app_cg");
+     app_cg = new(name);
+-    app_cfg_reg_cg = new(name);
++    app_cfg_reg_cg = new({name, "_cfg_reg"});
+   endfunction
+ 
+   function void app_sample(bit single_beat,
+-                           bit [keymgr_pkg::KmacDataIfWidth/8-1:0] strb,
++                           bit [kmac_pkg::MsgWidth/8-1:0] strb,
+                            bit err,
+                            bit is_done,
+                            bit in_keccak);
+diff --git a/dv/env/kmac_env_pkg.sv b/dv/env/kmac_env_pkg.sv
+index 3cf6e591..88ebe476 100644
+--- a/dv/env/kmac_env_pkg.sv
++++ b/dv/env/kmac_env_pkg.sv
+@@ -19,7 +19,6 @@ package kmac_env_pkg;
+   import kmac_app_agent_pkg::*;
+   import kmac_ral_pkg::*;
+   import kmac_pkg::*;
+-  import keymgr_pkg::*;
+   import key_sideload_agent_pkg::*;
+   import sec_cm_pkg::*;
+ 
+diff --git a/dv/env/kmac_scoreboard.sv b/dv/env/kmac_scoreboard.sv
+index a6222f68..018009c7 100644
+--- a/dv/env/kmac_scoreboard.sv
++++ b/dv/env/kmac_scoreboard.sv
+@@ -110,8 +110,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
+   // key length enum
+   key_len_e key_len;
+ 
+-  bit [keymgr_pkg::KmacDataIfWidth-1:0]   kmac_app_block_data;
+-  bit [keymgr_pkg::KmacDataIfWidth/8-1:0] kmac_app_block_strb;
++  bit [kmac_pkg::MsgWidth-1:0]   kmac_app_block_data;
++  bit [kmac_pkg::MsgWidth/8-1:0] kmac_app_block_strb;
+   int kmac_app_block_strb_size = 0;
+   bit kmac_app_last;
+ 
+@@ -263,13 +263,13 @@ class kmac_scoreboard extends cip_base_scoreboard #(
+ 
+             // Once valid sideload keys have been seen, update scoreboard state.
+             //
+-            // Note: max size of sideloaded key is keymgr_pkg::KeyWidth
++            // Note: max size of sideloaded key is kmac_pkg::KeyWidth
+ 
+             sideload_key = cfg.keymgr_sideload_agent_cfg.vif.sideload_key;
+ 
+             `uvm_info(`gfn, $sformatf("detected valid sideload_key: %0p", sideload_key), UVM_HIGH)
+ 
+-            for (int i = 0; i < keymgr_pkg::KeyWidth / 32; i++) begin
++            for (int i = 0; i < kmac_pkg::KeyWidth / 32; i++) begin
+               keymgr_keys[0][i] = sideload_key.key[0][i*32 +: 32];
+               keymgr_keys[1][i] = sideload_key.key[1][i*32 +: 32];
+             end
+@@ -287,12 +287,12 @@ class kmac_scoreboard extends cip_base_scoreboard #(
+   // Get sideload keys, pack and return the keys.
+   virtual function bit [KMAC_NUM_SHARES-1:0][KMAC_NUM_KEYS_PER_SHARE-1:0][31:0] get_keymgr_keys();
+     bit [KMAC_NUM_SHARES-1:0][KMAC_NUM_KEYS_PER_SHARE-1:0][31:0] keymgr_keys;
+-    keymgr_pkg::hw_key_req_t sideload_key;
++    kmac_pkg::hw_key_req_t sideload_key;
+ 
+     if (cfg.keymgr_sideload_agent_cfg.vif.sideload_key.valid) begin
+       sideload_key = cfg.keymgr_sideload_agent_cfg.vif.sideload_key;
+       `uvm_info(`gfn, $sformatf("get valid sideload_key: %0p", sideload_key), UVM_HIGH)
+-      for (int i = 0; i < keymgr_pkg::KeyWidth / 32; i++) begin
++      for (int i = 0; i < kmac_pkg::KeyWidth / 32; i++) begin
+         keymgr_keys[0][i] = sideload_key.key[0][i*32 +: 32];
+         keymgr_keys[1][i] = sideload_key.key[1][i*32 +: 32];
+       end
+@@ -561,7 +561,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
+                 // sample coverage
+                 if (cfg.en_cov) begin
+                   cov.app_cg_wrappers[app_mode].app_sample(
+-                    kmac_app_rsp.byte_data_q.size() <= keymgr_pkg::KmacDataIfWidth/8,
++                    kmac_app_rsp.byte_data_q.size() <= kmac_pkg::MsgWidth/8,
+                     '0,
+                     kmac_app_rsp.rsp_error,
+                     1,
+diff --git a/dv/env/seq_lib/kmac_smoke_vseq.sv b/dv/env/seq_lib/kmac_smoke_vseq.sv
+index ddb1021b..70ee26ba 100644
+--- a/dv/env/seq_lib/kmac_smoke_vseq.sv
++++ b/dv/env/seq_lib/kmac_smoke_vseq.sv
+@@ -103,8 +103,8 @@ class kmac_smoke_vseq extends kmac_base_vseq;
+   // Do a full message hash, repeated num_trans times
+   task body();
+ 
+-    logic [keymgr_pkg::KeyWidth-1:0] sideload_share0;
+-    logic [keymgr_pkg::KeyWidth-1:0] sideload_share1;
++    logic [kmac_pkg::KeyWidth-1:0] sideload_share0;
++    logic [kmac_pkg::KeyWidth-1:0] sideload_share1;
+     key_sideload_set_seq sideload_seq;
+ 
+     `uvm_info(`gfn, $sformatf("Starting %0d message hashes", num_trans), UVM_LOW)
+diff --git a/dv/tb.sv b/dv/tb.sv
+index 3c145ca1..ac702a7c 100644
+--- a/dv/tb.sv
++++ b/dv/tb.sv
+@@ -17,7 +17,7 @@ module tb;
+   wire clk, rst_n, rst_shadowed_n;
+   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+   // keymgr/kmac sideload wires
+-  keymgr_pkg::hw_key_req_t kmac_sideload_key;
++  kmac_pkg::hw_key_req_t kmac_sideload_key;
+   // kmac_app interfaces
+   kmac_pkg::app_req_t [NUM_APP_INTF-1:0] app_req;
+   kmac_pkg::app_rsp_t [NUM_APP_INTF-1:0] app_rsp;

--- a/hw/vendor/patches/lowrisc_ip/kmac/0004-Guard-masked-entropy-asserts.patch
+++ b/hw/vendor/patches/lowrisc_ip/kmac/0004-Guard-masked-entropy-asserts.patch
@@ -1,0 +1,45 @@
+diff --git a/dv/env/seq_lib/kmac_common_vseq.sv b/dv/env/seq_lib/kmac_common_vseq.sv
+index 481e7451..1382fc16 100644
+--- a/dv/env/seq_lib/kmac_common_vseq.sv
++++ b/dv/env/seq_lib/kmac_common_vseq.sv
+@@ -18,10 +18,12 @@ class kmac_common_vseq extends kmac_base_vseq;
+     if (common_seq_type inside {"shadow_reg_errors", "shadow_reg_errors_with_csr_rw"}) begin
+       csr_excl_item csr_excl = ral.get_excl_item();
+       // Shadow storage fatal error might cause req to drop without ack.
++`ifdef KMAC_MASKING
+       $assertoff(0,
+       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
+       $assertoff(0,
+       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
++`endif
+       $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
+       $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+     end
+diff --git a/dv/env/seq_lib/kmac_lc_escalation_vseq.sv b/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+index bbf9e55d..d7ba893f 100644
+--- a/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
++++ b/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+@@ -8,8 +8,10 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
+   `uvm_object_new
+ 
+   virtual function void disable_asserts();
++`ifdef KMAC_MASKING
+     $assertoff(0,
+       "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
++`endif
+     $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
+     $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+   endfunction
+diff --git a/dv/kmac_base_sim_cfg.hjson b/dv/kmac_base_sim_cfg.hjson
+index 7ffdffb7..d07d3ef5 100644
+--- a/dv/kmac_base_sim_cfg.hjson
++++ b/dv/kmac_base_sim_cfg.hjson
+@@ -63,7 +63,7 @@
+   build_modes: [
+     {
+       name: enable_mask_mode
+-      build_opts: ["+define+EN_MASKING=1", "+define+SW_KEY_MASKED=0"]
++      build_opts: ["+define+EN_MASKING=1", "+define+SW_KEY_MASKED=0", "+define+KMAC_MASKING"]
+       run_opts: ["+enable_masking=1", "+sw_key_masked=0"]
+     }
+     {


### PR DESCRIPTION
KMAC sanity regression can be ran with:
```
dvsim hw/vendor/lowrisc_ip/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson -i nightly -r 1 --tool xcelium
```