### PR TITLE
feat: modify the existing default devshell to use edaShell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,0 @@
-# Copyright lowRISC contributors (COSMIC project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
-
-# activate the default devshell
-use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,109 +24,40 @@ jobs:
   lint-check:
     runs-on: ["self-hosted", "nixos", "X64"]
 
-    defaults:
-      run:
-        shell: "nix develop -c bash -e {0}"
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare Nix environment
-        run: |
-          true
+        run: nix run .#ci -- warmup
 
-      - name: License check
-        run: |
-          reuse lint
-
-      - name: Check auto-generated artefacts
-        run: |
-          util/artefacts.py --check
-
-      - name: Lint - Ruff
-        run: |
-          ruff check
-
-      - name: Generate software buildsystem
-        run: |
-          cmake -B build/sw -S sw
-
-      - name: Lint - Clang Format
-        run: |
-          util/clang_format.py -i --dry-run -Werror
-
-      - name: Lint - Clang Tidy
-        run: |
-          util/clang_tidy.py
-
-      - name: Tool schema validation
-        run: |
-          util/tool_schema_validate.py
+      - name: Lint
+        run: nix run .#ci -- lint
 
   verilator-test:
     runs-on: ["self-hosted", "nixos", "X64"]
     needs: lint-check
 
-    defaults:
-      run:
-        shell: "nix develop -c bash -e {0}"
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare Nix environment
-        run: |
-          true
+        run: nix run .#ci -- warmup
 
-      - name: Generate software buildsystem
-        run: |
-          cmake -B build/sw -S sw
-
-      - name: Build software
-        run: |
-          cmake --build build/sw -j $(nproc)
-
-      - name: Build verilator
-        run: |
-          JOBS=$(($(nproc) / 4))
-          MAKEFLAGS="-j$JOBS" fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:mocha:top_chip_verilator
-
-      - name: Run verilator software tests
-        # Exclude tests marked 'slow' from quick CI runs.
-        run: |
-          ctest --test-dir build/sw -R sim_verilator -LE slow --output-on-failure -j $(nproc)
+      - name: Verilator tests
+        run: nix run .#ci -- verilator-test
 
   verilator-debug-test:
     runs-on: ["self-hosted", "nixos", "X64"]
     needs: lint-check
 
-    defaults:
-      run:
-        shell: "nix develop -c bash -e {0}"
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare Nix environment
-        run: |
-          true
+        run: nix run .#ci -- warmup
 
-      - name: Generate software buildsystem
-        run: |
-          cmake -B build/sw -S sw
-
-      - name: Build software
-        run: |
-          cmake --build build/sw -j $(nproc) --target bootrom --target infinite_loop
-
-      - name: Build verilator
-        run: |
-          JOBS=$(($(nproc) / 4))
-          MAKEFLAGS="-j$JOBS" fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:mocha:top_chip_verilator
-
-      - name: Run verilator debug test
-        run: |
-          util/debug_test_verilator.sh
+      - name: Verilator debug test
+        run: nix run .#ci -- verilator-debug-test
 
   fpga-cache-check:
     runs-on: ["self-hosted", "nixos", "X64"]
@@ -216,22 +147,14 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Build software
-        shell: "nix develop -c bash -e {0}"
-        run: |
-          cmake -B build/sw -S sw
-          cmake --build build/sw -j $(nproc)
+        run: nix run .#ci -- sw-build
 
       - name: Flash bitstream
         run: |
           nix run .#bitstream-load
 
       - name: Run FPGA tests
-        # Exclude tests marked 'slow' from quick CI runs.
-        shell: "nix develop -c bash -e {0}"
-        run: |
-          ctest --test-dir build/sw -R fpga -LE slow --output-on-failure
+        run: nix run .#ci -- fpga-test
 
       - name: Run FPGA debug test
-        shell: "nix develop -c bash -e {0}"
-        run: |
-          util/debug_test_fpga.sh
+        run: nix run .#ci -- fpga-debug-test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,34 +12,11 @@ jobs:
   slow-verilator-test:
     runs-on: ["self-hosted", "nixos", "X64"]
 
-    defaults:
-      run:
-        shell: "nix develop -c bash -e {0}"
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare Nix environment
-        run: |
-          true
+        run: nix run .#ci -- warmup
 
-      - name: Generate software buildsystem
-        run: |
-          cmake -B build/sw -S sw
-
-      - name: Build software
-        run: |
-          cmake --build build/sw -j $(nproc)
-
-      - name: Build verilator
-        run: |
-          JOBS=$(($(nproc) / 4))
-          fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:mocha:top_chip_verilator \
-            --verilator_options="-j ${JOBS} --threads 2 --trace-threads 2" --make_options="-j ${JOBS}"
-
-      - name: Run Slow Verilator tests
-        # Display the tests that are about to be ran with '--show-only' first.
-        run: |
-          ctest --test-dir build/sw -R sim_verilator -L slow --show-only
-
-          ctest --test-dir build/sw -R sim_verilator -L slow --output-on-failure
+      - name: Slow Verilator tests
+        run: nix run .#ci -- verilator-slow-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,21 +51,14 @@ jobs:
     env:
       ARTEFACT: build/lowrisc_mocha_top_chip_verilator_0/sim-verilator/Vtop_chip_verilator
 
-    defaults:
-      run:
-        shell: "nix develop -c bash -e {0}"
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare Nix environment
-        run: |
-          true
+        run: nix run .#ci -- warmup
 
       - name: Build verilator
-        run: |
-          JOBS=$(($(nproc) / 2))
-          MAKEFLAGS="-j$JOBS" fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:mocha:top_chip_verilator
+        run: nix run .#ci -- verilator-release
 
       - uses: softprops/action-gh-release@v2
         if: github.ref_type == 'tag'
@@ -78,26 +71,16 @@ jobs:
     env:
       ARTEFACT: release_software.tar.gz
 
-    defaults:
-      run:
-        shell: "nix develop -c bash -e {0}"
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare Nix environment
-        run: |
-          true
+        run: nix run .#ci -- warmup
 
       - name: Generate artefacts
-        run: |
-          cmake -B build/sw -S sw
-          cmake --build build/sw -j$(nproc)
-          cmake --install build/sw --prefix release/examples --component examples
-          cmake --install build/sw --prefix release --component bootrom
-          cmake --install build/sw --prefix release --component boot
-
-          tar -czvf ${{ env.ARTEFACT }} release
+        run: nix run .#ci -- software-release
+        env:
+          MOCHA_RELEASE_ARTEFACT: ${{ env.ARTEFACT }}
 
       - uses: softprops/action-gh-release@v2
         if: github.ref_type == 'tag'

--- a/ci/jobs.toml
+++ b/ci/jobs.toml
@@ -1,0 +1,108 @@
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The CI jobs: one table per job, named after the CI job the workflows call by
+# name. ci/run.py reads this file and nothing else decides what a job does.
+#
+# Each entry in `steps` is either
+#
+#   { run = "<command line>" }   a command, written as you would type it. A
+#                                bare first word naming a script in ci/scripts
+#                                (sw-build, verilator-build, ...) resolves to
+#                                that script, so `run = "sw-build --traced"`
+#                                and `--step sw-build --traced` are the same.
+#   { job = "<job>" }            another job's steps, run at this point.
+#
+# A step the rest of its job depends on, a configure or a build, is
+# `required = true`: if it fails the run stops there. Any other step records
+# its failure and the job carries on, so one run reports every problem it can
+# find. A step reached twice over runs once, the first time it is reached.
+
+[jobs.sw-configure]
+steps = [
+  { run = "cmake -B build/sw -S sw", required = true },
+]
+
+# clang-format and clang-tidy read the compilation database, so the
+# buildsystem has to exist before them.
+[jobs.lint]
+steps = [
+  { run = "reuse lint" },
+  { run = "util/artefacts.py --check" },
+  { run = "ruff check" },
+  { job = "sw-configure" },
+  { run = "util/clang_format.py -i --dry-run -Werror" },
+  { run = "util/clang_tidy.py" },
+  { run = "util/tool_schema_validate.py" },
+]
+
+# The FPGA jobs build the software here, then the workflow flashes the board
+# between this job and fpga-test.
+[jobs.sw-build]
+steps = [
+  { job = "sw-configure" },
+  { run = "sw-build", required = true },
+]
+
+[jobs.verilator-test]
+steps = [
+  { job = "sw-build" },
+  { run = "verilator-build", required = true },
+  { run = "verilator-test" },
+]
+
+# The debug test only needs a bootrom to run and something to step through, so
+# it builds those targets rather than the whole tree.
+[jobs.verilator-debug-test]
+steps = [
+  { job = "sw-configure" },
+  { run = "sw-build --target bootrom --target infinite_loop", required = true },
+  { run = "verilator-build", required = true },
+  { run = "util/debug_test_verilator.sh" },
+]
+
+[jobs.verilator-slow-test]
+steps = [
+  { job = "sw-build" },
+  { run = "verilator-build --traced", required = true },
+  { run = "verilator-slow-test" },
+]
+
+# Needs the software built and the bitstream loaded, which the workflow does
+# with `nix run .#bitstream-load` outside the devshell.
+[jobs.fpga-test]
+steps = [
+  { run = "ctest --test-dir build/sw -R fpga -LE slow --output-on-failure" },
+]
+
+[jobs.fpga-debug-test]
+steps = [
+  { run = "util/debug_test_fpga.sh" },
+]
+
+# Releases get a faster model build than CI: nothing shares the machine.
+[jobs.verilator-release]
+steps = [
+  { run = "verilator-build --jobs-divisor 2", required = true },
+]
+
+[jobs.software-release]
+steps = [
+  { job = "sw-build" },
+  { run = "sw-release", required = true },
+]
+
+[jobs.warmup]
+steps = [
+  { run = "env-info" },
+]
+
+# Every job that does not need an FPGA board attached. The local pre-push run.
+[jobs.all]
+steps = [
+  { job = "warmup" },
+  { job = "lint" },
+  { job = "verilator-test" },
+  { job = "verilator-debug-test" },
+]

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the CI steps and the job runner (ci/run.py).
+
+Standard library only, like the rest of util/: the CI flow has to work in a
+fresh devshell without anything installed on top of it.
+
+Commands run from the repository root, so a step can use the paths the
+buildsystem does (build/sw, sw, util/...) wherever it was invoked from.
+"""
+
+import argparse
+import contextlib
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+REPO_TOP = Path(__file__).resolve().parents[1]
+
+# How a run is asked to stop: SIGINT from Ctrl-C at the terminal or from a
+# cancelled Actions job, SIGTERM from the runner when SIGINT was not enough.
+STOP_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+
+# How long a command gets to stop of its own accord before it is killed.
+GRACE_SECONDS = 10
+
+
+def jobs() -> int:
+    """How many jobs to build with: $MOCHA_JOBS, or every core."""
+    value = os.environ.get("MOCHA_JOBS", "").strip()
+    if not value:
+        return os.cpu_count() or 1
+    try:
+        return max(1, int(value))
+    except ValueError:
+        raise SystemExit(f"$MOCHA_JOBS is not a number: {value!r}") from None
+
+
+def quote(argv: list) -> str:
+    """A command line, as you would type it."""
+    return shlex.join(str(arg) for arg in argv)
+
+
+def parser(description: str) -> argparse.ArgumentParser:
+    """An argument parser for a step, with the options every step takes."""
+    step_parser = argparse.ArgumentParser(description=description)
+    step_parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="print the commands this step runs, run nothing",
+    )
+    return step_parser
+
+
+def signal_group(group: int, signum: int) -> None:
+    """Signal a process group, which may already have gone."""
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(group, signum)
+
+
+def stop(group: int, signum: int) -> "threading.Timer":
+    """Pass a stop signal on to a command and everything it started, and start
+    the clock on killing the group outright if it does not go.
+
+    An orphaned ctest or nix build holds the FPGA board and keeps a cancelled
+    job alive until the runner gives up on it, so nothing is left to outlive
+    the grace period.
+
+    Nothing here waits on the command: this runs in a signal handler, on the
+    thread already waiting for it, and a second wait would deadlock against
+    the first. The grace period is a timer instead, and the interrupted wait
+    picks the exit up as it would any other.
+    """
+    signal_group(group, signum)
+
+    def out_of_time() -> None:
+        print(
+            f"Command did not stop within {GRACE_SECONDS}s; killing it.",
+            file=sys.stderr,
+            flush=True,
+        )
+        signal_group(group, signal.SIGKILL)
+
+    timer = threading.Timer(GRACE_SECONDS, out_of_time)
+    timer.daemon = True
+    timer.start()
+    return timer
+
+
+def run(
+    *argv, env: "dict | None" = None, dry_run: bool = False, check: bool = True
+) -> int:
+    """Run one command from the repository root and return its exit status.
+
+    With dry_run, print the command instead of running it. With check, a
+    non-zero status raises SystemExit, which is what a step wants: it stops
+    there and ci/run.py reports the step as failed.
+
+    A stop signal is not a failed step: the command and everything it started
+    are taken down and SystemExit is raised whatever `check` says, so the run
+    ends here rather than carrying on into steps that would run against a job
+    already being torn down.
+
+    $MOCHA_VERBOSE (set by `ci/run.py --verbose`) echoes each command as it
+    runs, so a real run says what it did, not just what it was asked to do.
+    """
+    command = [str(arg) for arg in argv]
+    # Show any environment the command is run with the way you would set it.
+    prefix = "".join(f"{name}={quote([value])} " for name, value in (env or {}).items())
+
+    if dry_run:
+        print(f"{prefix}{quote(command)}")
+        return 0
+
+    if os.environ.get("MOCHA_VERBOSE"):
+        print(f"+ {prefix}{quote(command)}", flush=True)
+
+    process = subprocess.Popen(
+        command,
+        cwd=REPO_TOP,
+        env={**os.environ, **(env or {})},
+        # Its own process group, so a stop signal can be delivered to the
+        # command and everything it spawned together rather than to the
+        # leader alone.
+        start_new_session=True,
+    )
+
+    # start_new_session makes the command the leader of its own group, so its
+    # pid is the group to signal.
+    group = process.pid
+    stopped = None
+    timer = None
+    previous = {}
+
+    def on_signal(signum, _frame):
+        nonlocal stopped, timer
+        stopped = signum
+        timer = stop(group, signum)
+
+    try:
+        for one in STOP_SIGNALS:
+            previous[one] = signal.signal(one, on_signal)
+        status = process.wait()
+    finally:
+        for one, handler in previous.items():
+            signal.signal(one, handler)
+        if timer is not None:
+            timer.cancel()
+
+    if stopped is not None:
+        # The command has gone, but something it spawned can still be holding
+        # the board, so take the group with it.
+        signal_group(group, signal.SIGKILL)
+        raise SystemExit(128 + stopped)
+
+    # A command killed by a signal comes back as -N. Report it the way a shell
+    # does, so what this returns is always a real exit status.
+    if status < 0:
+        status = 128 + -status
+
+    if status and check:
+        raise SystemExit(status)
+    return status

--- a/ci/run.py
+++ b/ci/run.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI job runner: what each CI job does, so a job and a local run of it are the
+same command in the same shell.
+
+    nix run .#ci -- <job>...             run these jobs, in order
+    nix run .#ci -- all                  every job that needs no FPGA board
+    nix run .#ci -- --step <cmd> [args]  run a single step
+    nix run .#ci -- --list               list the jobs and their steps
+    nix run .#ci -- --dry-run <job>...   print the steps, run nothing
+    nix run .#ci -- --verbose ...        with --dry-run, ask each of our steps
+                                         what it would run; otherwise echo the
+                                         commands as they run
+
+From inside `nix develop` the same thing spelled ci/run.py <job>.
+
+A step is a command: a tool the devshell provides, one of the repository's
+util/ scripts, or -- where a step needs arguments worked out, or is more than
+one command -- a script in ci/scripts. Steps run from the repository root and
+each is runnable on its own.
+
+A step the rest of its job depends on, a configure or a build, is Required():
+if it fails the run stops there. Any other step records its failure and the job
+carries on, so one run reports every problem it can find.
+
+A job can also name another job, Job("name"), to run its steps at that point:
+the sequences are written once and composed rather than restated. A step
+reached twice over runs once, the first time it is reached.
+
+Parallelism comes from $MOCHA_JOBS (default: every core), so
+`MOCHA_JOBS=8 nix run .#ci -- verilator-test` leaves a machine usable.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from typing import NamedTuple, Union
+
+import lib
+
+
+class Step(NamedTuple):
+    """A command to run, and whether the rest of its job depends on it."""
+
+    argv: tuple
+    required: bool = False
+
+
+class Job(NamedTuple):
+    """Another job's steps, run at this point in the list."""
+
+    name: str
+
+
+# Reads as a kind of step rather than a function, hence the capital.
+def Required(*argv) -> Step:
+    return Step(tuple(argv), required=True)
+
+
+def step(*argv) -> Step:
+    return Step(tuple(argv))
+
+
+def ci_script(name: str, *args) -> tuple:
+    """One of our own steps, by its job-style name."""
+    return (f"ci/scripts/{name.replace('-', '_')}.py", *args)
+
+
+# ---------------------------------------------------------------------------
+# The jobs. One per CI job, named after it; the workflows call these by name.
+# ---------------------------------------------------------------------------
+
+JOBS: "dict[str, list[Union[Step, Job]]]" = {
+    "sw-configure": [
+        Required("cmake", "-B", "build/sw", "-S", "sw"),
+    ],
+    # clang-format and clang-tidy read the compilation database, so the
+    # buildsystem has to exist before them.
+    "lint": [
+        step("reuse", "lint"),
+        step("util/artefacts.py", "--check"),
+        step("ruff", "check"),
+        Job("sw-configure"),
+        step("util/clang_format.py", "-i", "--dry-run", "-Werror"),
+        step("util/clang_tidy.py"),
+        step("util/tool_schema_validate.py"),
+    ],
+    # The FPGA jobs build the software here, then the workflow flashes the
+    # board between this job and fpga-test.
+    "sw-build": [
+        Job("sw-configure"),
+        Required(*ci_script("sw-build")),
+    ],
+    "verilator-test": [
+        Job("sw-build"),
+        Required(*ci_script("verilator-build")),
+        step(*ci_script("verilator-test")),
+    ],
+    # The debug test only needs a bootrom to run and something to step through,
+    # so it builds those targets rather than the whole tree.
+    "verilator-debug-test": [
+        Job("sw-configure"),
+        Required(*ci_script("sw-build"), "--target", "bootrom", "--target", "infinite_loop"),
+        Required(*ci_script("verilator-build")),
+        step("util/debug_test_verilator.sh"),
+    ],
+    "verilator-slow-test": [
+        Job("sw-build"),
+        Required(*ci_script("verilator-build"), "--traced"),
+        step(*ci_script("verilator-slow-test")),
+    ],
+    # Needs the software built and the bitstream loaded, which the workflow
+    # does with `nix run .#bitstream-load` outside the devshell.
+    "fpga-test": [
+        step("ctest", "--test-dir", "build/sw", "-R", "fpga", "-LE", "slow", "--output-on-failure"),
+    ],
+    "fpga-debug-test": [
+        step("util/debug_test_fpga.sh"),
+    ],
+    # Releases get a faster model build than CI: nothing shares the machine.
+    "verilator-release": [
+        Required(*ci_script("verilator-build"), "--jobs-divisor", "2"),
+    ],
+    "software-release": [
+        Job("sw-build"),
+        Required(*ci_script("sw-release")),
+    ],
+    "warmup": [
+        step(*ci_script("env-info")),
+    ],
+    # Every job that does not need an FPGA board attached. The local pre-push
+    # run.
+    "all": [
+        Job("warmup"),
+        Job("lint"),
+        Job("verilator-test"),
+        Job("verilator-debug-test"),
+    ],
+}
+
+MAX_DEPTH = 8
+
+
+def job_steps(job: str, depth: int = 0) -> "list[Step]":
+    """The steps a job runs: Job() references expanded in place, and any step
+    reached more than once kept only where it is first reached.
+
+    This is what runs, what --list shows and what --dry-run prints.
+    """
+    if depth > MAX_DEPTH:
+        raise SystemExit(f"Job references nested too deeply at '{job}'.")
+    if job not in JOBS:
+        raise SystemExit(f"No such job: {job}")
+
+    steps: "list[Step]" = []
+    seen = set()
+    for entry in JOBS[job]:
+        expanded = job_steps(entry.name, depth + 1) if isinstance(entry, Job) else [entry]
+        for one in expanded:
+            if one.argv in seen:
+                continue
+            seen.add(one.argv)
+            steps.append(one)
+    return steps
+
+
+# ---------------------------------------------------------------------------
+# Running them
+# ---------------------------------------------------------------------------
+
+
+def section(title: str) -> None:
+    """A header, collapsible under GitHub Actions."""
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::group::{title}", flush=True)
+    else:
+        print(f"\n\033[1m### {title}\033[0m", flush=True)
+
+
+def endsection() -> None:
+    if os.environ.get("GITHUB_ACTIONS"):
+        print("::endgroup::", flush=True)
+
+
+def is_ours(argv: tuple) -> bool:
+    """Whether a step is one of ours, and so takes --dry-run."""
+    return str(argv[0]).startswith("ci/scripts/")
+
+
+def runnable(cmd: str) -> bool:
+    """Whether a step's command exists, as a file here or a tool on $PATH."""
+    return (lib.REPO_TOP / cmd).is_file() or shutil.which(cmd) is not None
+
+
+def resolve(token: str) -> str:
+    """The command a step name refers to: a bare name is a script in
+    ci/scripts, so `--step sw-build` works as well as the path the jobs use.
+    """
+    candidate = lib.REPO_TOP / f"ci/scripts/{token.replace('-', '_')}.py"
+    return str(candidate.relative_to(lib.REPO_TOP)) if candidate.is_file() else token
+
+
+def print_step(one: Step, verbose: bool) -> None:
+    """Print a step, and with verbose the commands one of our own steps runs.
+
+    The expansion comes from the step itself, run with --dry-run, so this
+    cannot drift from what a real run would do.
+    """
+    line = lib.quote(list(one.argv))
+    print(f"{line:<46} # required" if one.required else line)
+
+    if not (verbose and is_ours(one.argv)):
+        return
+
+    expanded = subprocess.run(
+        [sys.executable, *one.argv, "--dry-run"],
+        cwd=lib.REPO_TOP,
+        capture_output=True,
+        text=True,
+    )
+    for expansion in expanded.stdout.splitlines():
+        print(f"    | {expansion}")
+
+    # A step that cannot say what it would run is a bug in the step, not
+    # something to pass over quietly.
+    if expanded.returncode:
+        print(f"    | (could not expand: {expanded.stderr.strip()})")
+
+    print()
+
+
+def run_step(one: Step) -> int:
+    section(lib.quote(list(one.argv)))
+    try:
+        status = lib.run(*one.argv, check=False)
+    except OSError as error:
+        print(f"Could not run step: {error}", file=sys.stderr)
+        status = 127
+    finally:
+        # A stop signal leaves through here as SystemExit, and an unclosed
+        # group swallows everything the log has left to say about why.
+        endsection()
+    return status
+
+
+def run_job(job: str, failures: list, dry_run: bool, verbose: bool) -> None:
+    """Run (or print) one job's steps, in order."""
+    if dry_run:
+        print(f"# job: {job}")
+
+    for one in job_steps(job):
+        if dry_run:
+            print_step(one, verbose)
+            continue
+
+        if run_step(one) == 0:
+            continue
+
+        print(f"::error::CI step failed: {one.argv[0]}", file=sys.stderr)
+        failures.append(f"{job} / {one.argv[0]}")
+
+        if one.required:
+            print(f"Stopping: the rest of '{job}' depends on it.", file=sys.stderr)
+            report(failures)
+            raise SystemExit(1)
+
+
+def report(failures: list) -> int:
+    if not failures:
+        print("\nAll steps passed.")
+        return 0
+    print(f"\n{len(failures)} step(s) failed:", file=sys.stderr)
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    return 1
+
+
+def show_list() -> None:
+    print("Jobs:")
+    for job in JOBS:
+        print(f"  {job}")
+        for one in job_steps(job):
+            mark = "!" if one.required else " "
+            print(f"      {mark}{lib.quote(list(one.argv))}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("jobs", nargs="*", metavar="job", help="jobs to run, in order")
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="print the steps, run nothing",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="expand our own steps under --dry-run; otherwise echo commands as they run",
+    )
+    parser.add_argument(
+        "-l", "--list", action="store_true", help="list the jobs and their steps"
+    )
+    parser.add_argument(
+        "--step",
+        nargs=argparse.REMAINDER,
+        metavar="cmd",
+        help="run a single step: a name from ci/scripts, or any command",
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        show_list()
+        return 0
+
+    if args.verbose and not args.dry_run:
+        # Picked up by lib.run in every step, so a real run echoes what it does.
+        os.environ["MOCHA_VERBOSE"] = "1"
+
+    if args.step:
+        token = args.step[0]
+        one = Step((resolve(token), *args.step[1:]))
+        # A job whose steps are all plain commands has no script of its own, so
+        # say what to run rather than reporting its name as a missing file.
+        if token in JOBS and not runnable(one.argv[0]):
+            print(f"'{token}' is a job, not a step. Run: ci/run.py {token}", file=sys.stderr)
+            return 1
+        if args.dry_run:
+            print_step(one, args.verbose)
+            return 0
+        return run_step(one)
+
+    if not args.jobs:
+        parser.print_help()
+        return 1
+
+    unknown = [job for job in args.jobs if job not in JOBS]
+    if unknown:
+        print(f"Unknown job: {', '.join(unknown)}\n", file=sys.stderr)
+        show_list()
+        return 1
+
+    failures: list = []
+    for job in args.jobs:
+        run_job(job, failures, args.dry_run, args.verbose)
+
+    # Nothing ran, so there is nothing to report on.
+    return 0 if args.dry_run else report(failures)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/run.py
+++ b/ci/run.py
@@ -17,18 +17,21 @@ same command in the same shell.
 
 From inside `nix develop` the same thing spelled ci/run.py <job>.
 
+The jobs themselves are described in ci/jobs.toml, which is the only place
+that says what a job does; this runs what it describes.
+
 A step is a command: a tool the devshell provides, one of the repository's
 util/ scripts, or -- where a step needs arguments worked out, or is more than
-one command -- a script in ci/scripts. Steps run from the repository root and
-each is runnable on its own.
+one command -- a script in ci/scripts, named there as `run = "sw-build"`.
+Steps run from the repository root and each is runnable on its own.
 
-A step the rest of its job depends on, a configure or a build, is Required():
-if it fails the run stops there. Any other step records its failure and the job
-carries on, so one run reports every problem it can find.
+A step the rest of its job depends on, a configure or a build, is written
+`required = true`: if it fails the run stops there. Any other step records its
+failure and the job carries on, so one run reports every problem it can find.
 
-A job can also name another job, Job("name"), to run its steps at that point:
-the sequences are written once and composed rather than restated. A step
-reached twice over runs once, the first time it is reached.
+A job can also name another job, `{ job = "name" }`, to run its steps at that
+point: the sequences are written once and composed rather than restated. A
+step reached twice over runs once, the first time it is reached.
 
 Parallelism comes from $MOCHA_JOBS (default: every core), so
 `MOCHA_JOBS=8 nix run .#ci -- verilator-test` leaves a machine usable.
@@ -36,9 +39,11 @@ Parallelism comes from $MOCHA_JOBS (default: every core), so
 
 import argparse
 import os
+import shlex
 import shutil
 import subprocess
 import sys
+import tomllib
 from typing import NamedTuple, Union
 
 import lib
@@ -57,91 +62,80 @@ class Job(NamedTuple):
     name: str
 
 
-# Reads as a kind of step rather than a function, hence the capital.
-def Required(*argv) -> Step:
-    return Step(tuple(argv), required=True)
-
-
-def step(*argv) -> Step:
-    return Step(tuple(argv))
-
-
-def ci_script(name: str, *args) -> tuple:
-    """One of our own steps, by its job-style name."""
-    return (f"ci/scripts/{name.replace('-', '_')}.py", *args)
-
-
 # ---------------------------------------------------------------------------
 # The jobs. One per CI job, named after it; the workflows call these by name.
+# They are described in ci/jobs.toml, which is the only place that says what a
+# job does.
 # ---------------------------------------------------------------------------
 
-JOBS: "dict[str, list[Union[Step, Job]]]" = {
-    "sw-configure": [
-        Required("cmake", "-B", "build/sw", "-S", "sw"),
-    ],
-    # clang-format and clang-tidy read the compilation database, so the
-    # buildsystem has to exist before them.
-    "lint": [
-        step("reuse", "lint"),
-        step("util/artefacts.py", "--check"),
-        step("ruff", "check"),
-        Job("sw-configure"),
-        step("util/clang_format.py", "-i", "--dry-run", "-Werror"),
-        step("util/clang_tidy.py"),
-        step("util/tool_schema_validate.py"),
-    ],
-    # The FPGA jobs build the software here, then the workflow flashes the
-    # board between this job and fpga-test.
-    "sw-build": [
-        Job("sw-configure"),
-        Required(*ci_script("sw-build")),
-    ],
-    "verilator-test": [
-        Job("sw-build"),
-        Required(*ci_script("verilator-build")),
-        step(*ci_script("verilator-test")),
-    ],
-    # The debug test only needs a bootrom to run and something to step through,
-    # so it builds those targets rather than the whole tree.
-    "verilator-debug-test": [
-        Job("sw-configure"),
-        Required(*ci_script("sw-build"), "--target", "bootrom", "--target", "infinite_loop"),
-        Required(*ci_script("verilator-build")),
-        step("util/debug_test_verilator.sh"),
-    ],
-    "verilator-slow-test": [
-        Job("sw-build"),
-        Required(*ci_script("verilator-build"), "--traced"),
-        step(*ci_script("verilator-slow-test")),
-    ],
-    # Needs the software built and the bitstream loaded, which the workflow
-    # does with `nix run .#bitstream-load` outside the devshell.
-    "fpga-test": [
-        step("ctest", "--test-dir", "build/sw", "-R", "fpga", "-LE", "slow", "--output-on-failure"),
-    ],
-    "fpga-debug-test": [
-        step("util/debug_test_fpga.sh"),
-    ],
-    # Releases get a faster model build than CI: nothing shares the machine.
-    "verilator-release": [
-        Required(*ci_script("verilator-build"), "--jobs-divisor", "2"),
-    ],
-    "software-release": [
-        Job("sw-build"),
-        Required(*ci_script("sw-release")),
-    ],
-    "warmup": [
-        step(*ci_script("env-info")),
-    ],
-    # Every job that does not need an FPGA board attached. The local pre-push
-    # run.
-    "all": [
-        Job("warmup"),
-        Job("lint"),
-        Job("verilator-test"),
-        Job("verilator-debug-test"),
-    ],
-}
+# Named relative to the repository root, which is where the steps run and how
+# every message about the file reads.
+JOBS_FILE_NAME = "ci/jobs.toml"
+JOBS_FILE = lib.REPO_TOP / JOBS_FILE_NAME
+
+
+def resolve(token: str) -> str:
+    """The command a step name refers to: a bare name is a script in
+    ci/scripts, so `sw-build` in ci/jobs.toml, and `--step sw-build` on the
+    command line, both mean ci/scripts/sw_build.py.
+    """
+    candidate = lib.REPO_TOP / f"ci/scripts/{token.replace('-', '_')}.py"
+    return str(candidate.relative_to(lib.REPO_TOP)) if candidate.is_file() else token
+
+
+def read_step(job: str, index: int, entry) -> "Union[Step, Job]":
+    """One entry of a job's `steps`, as it is written in ci/jobs.toml.
+
+    Complaining here rather than at the point of use means a typo in the file
+    is reported as a typo, before any of the run has happened.
+    """
+    where = f"{JOBS_FILE_NAME}: jobs.{job}.steps[{index}]"
+    if not isinstance(entry, dict):
+        raise SystemExit(f"{where}: expected a table, not {type(entry).__name__}.")
+
+    unknown = set(entry) - {"run", "job", "required"}
+    if unknown:
+        raise SystemExit(f"{where}: unknown key(s): {', '.join(sorted(unknown))}.")
+    if ("run" in entry) == ("job" in entry):
+        raise SystemExit(f"{where}: needs exactly one of 'run' or 'job'.")
+
+    if "job" in entry:
+        if "required" in entry:
+            # A job reference has no status of its own; its steps carry theirs.
+            raise SystemExit(f"{where}: 'required' belongs on a 'run', not a 'job'.")
+        return Job(entry["job"])
+
+    argv = shlex.split(entry["run"])
+    if not argv:
+        raise SystemExit(f"{where}: 'run' is empty.")
+    return Step((resolve(argv[0]), *argv[1:]), required=bool(entry.get("required")))
+
+
+def read_jobs() -> "dict[str, list[Union[Step, Job]]]":
+    """The jobs, in the order ci/jobs.toml gives them."""
+    try:
+        with JOBS_FILE.open("rb") as source:
+            described = tomllib.load(source)
+    except OSError as error:
+        raise SystemExit(f"Could not read {JOBS_FILE_NAME}: {error}") from None
+    except tomllib.TOMLDecodeError as error:
+        raise SystemExit(f"{JOBS_FILE_NAME}: {error}") from None
+
+    jobs = described.get("jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        raise SystemExit(f"{JOBS_FILE_NAME}: no [jobs.<name>] tables.")
+
+    read = {}
+    for job, described_job in jobs.items():
+        steps = described_job.get("steps") if isinstance(described_job, dict) else None
+        if not isinstance(steps, list) or not steps:
+            raise SystemExit(f"{JOBS_FILE_NAME}: jobs.{job} needs a non-empty 'steps'.")
+        read[job] = [read_step(job, index, entry) for index, entry in enumerate(steps)]
+    return read
+
+
+JOBS: "dict[str, list[Union[Step, Job]]]" = read_jobs()
+
 
 MAX_DEPTH = 8
 
@@ -195,14 +189,6 @@ def is_ours(argv: tuple) -> bool:
 def runnable(cmd: str) -> bool:
     """Whether a step's command exists, as a file here or a tool on $PATH."""
     return (lib.REPO_TOP / cmd).is_file() or shutil.which(cmd) is not None
-
-
-def resolve(token: str) -> str:
-    """The command a step name refers to: a bare name is a script in
-    ci/scripts, so `--step sw-build` works as well as the path the jobs use.
-    """
-    candidate = lib.REPO_TOP / f"ci/scripts/{token.replace('-', '_')}.py"
-    return str(candidate.relative_to(lib.REPO_TOP)) if candidate.is_file() else token
 
 
 def print_step(one: Step, verbose: bool) -> None:

--- a/ci/scripts/env_info.py
+++ b/ci/scripts/env_info.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Print the environment the flow will run in.
+
+The repository, the job count, and the version and path of every tool the steps
+call. CI runs this first so the store downloads that realise the shell land
+here, instead of burying the output of the first real step -- and so a failure
+further down can be read against the versions it happened with.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib
+
+# Tools the steps call, and how each one is asked for its version. Most take
+# --version; expect wants -v, which is why this is a table and not a list.
+#
+# gdb and expect are here for the debug tests: on a machine with EDA tools
+# configured, their paths go ahead of the devshell's, and `gdb` can turn out to
+# be a vendor build that cannot run. That is worth seeing here rather than
+# halfway through a debug test.
+TOOLS = {
+    "cmake": ["--version"],
+    "ctest": ["--version"],
+    "fusesoc": ["--version"],
+    "verilator": ["--version"],
+    "openocd": ["--version"],
+    "gdb": ["--version"],
+    "expect": ["-v"],
+    "ruff": ["--version"],
+    "reuse": ["--version"],
+}
+
+MISSING = "<missing>"
+UNKNOWN = "<unknown>"
+TIMEOUT = 30
+
+
+def version(tool: str, args: list) -> str:
+    """What `tool --version` says, in one line.
+
+    Reported as the tool prints it, rather than a version dug out of it: the
+    formats differ ('cmake version 4.1.0', 'Verilator 5.040 2025-01-01') and a
+    log is better off with what the tool actually claims. stderr counts, since
+    openocd reports its version there.
+    """
+    try:
+        result = subprocess.run(
+            [tool, *args],
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT,
+            cwd=lib.REPO_TOP,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return UNKNOWN
+
+    for line in (result.stdout + result.stderr).splitlines():
+        if line.strip():
+            return " ".join(line.split())
+    return UNKNOWN
+
+
+def main() -> None:
+    parser = lib.parser(__doc__)
+    args = parser.parse_args()
+
+    if args.dry_run:
+        for tool, version_args in TOOLS.items():
+            print(lib.quote([tool, *version_args]))
+        return
+
+    print(f"repository: {lib.REPO_TOP}")
+    print(f"python:     {sys.version.split()[0]} ({sys.executable})")
+    print(f"jobs:       {lib.jobs()}")
+    print()
+
+    rows = []
+    for tool, version_args in TOOLS.items():
+        path = shutil.which(tool)
+        rows.append(
+            (
+                tool,
+                path or MISSING,
+                "" if not path else version(path, version_args),
+            )
+        )
+
+    # What a tool reports is last on the line, because it is the one field with
+    # no bound: a tool that cannot run reports its whole loader error, and that
+    # should not push every path off to the right.
+    name_width = max(len(row[0]) for row in rows)
+    path_width = max(len(row[1]) for row in rows)
+    for name, path, reported in rows:
+        print(f"{name:<{name_width}}  {path:<{path_width}}  {reported}".rstrip())
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/scripts/env_info.py
+++ b/ci/scripts/env_info.py
@@ -11,6 +11,7 @@ here, instead of burying the output of the first real step -- and so a failure
 further down can be read against the versions it happened with.
 """
 
+import os
 import shutil
 import subprocess
 import sys
@@ -37,6 +38,13 @@ TOOLS = {
     "expect": ["-v"],
     "ruff": ["--version"],
     "reuse": ["--version"],
+}
+
+# Tools a step takes from an environment variable rather than $PATH, so that
+# this reports the one the step will use. gdb is named by the devshell because
+# EDA tool paths come first in $PATH and can shadow it.
+FROM_ENV = {
+    "gdb": "GDB",
 }
 
 MISSING = "<missing>"
@@ -85,7 +93,8 @@ def main() -> None:
 
     rows = []
     for tool, version_args in TOOLS.items():
-        path = shutil.which(tool)
+        named = os.environ.get(FROM_ENV.get(tool, ""), "").strip()
+        path = named or shutil.which(tool)
         rows.append(
             (
                 tool,

--- a/ci/scripts/sw_build.py
+++ b/ci/scripts/sw_build.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the software in build/sw.
+
+With no arguments the whole tree; anything else is passed to cmake --build, to
+narrow it:
+
+    ci/scripts/sw_build.py --target bootrom --target infinite_loop
+
+Parallelism comes from $MOCHA_JOBS (default: every core).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib
+
+
+def main() -> None:
+    parser = lib.parser(__doc__)
+    # Unrecognised arguments (--target ...) are passed straight to cmake, so
+    # they need no separator on the command line.
+    args, cmake_args = parser.parse_known_args()
+
+    lib.run(
+        "cmake",
+        "--build",
+        "build/sw",
+        "-j",
+        lib.jobs(),
+        *cmake_args,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/scripts/sw_release.py
+++ b/ci/scripts/sw_release.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package the software release artefact.
+
+Installs the release components out of build/sw and tars them up. The archive
+name comes from the argument, or $MOCHA_RELEASE_ARTEFACT, and must match what
+the release workflow uploads. Needs the software built.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib
+
+DEFAULT_ARTEFACT = "release_software.tar.gz"
+
+# component -> prefix to install it under
+COMPONENTS = {
+    "examples": "release/examples",
+    "bootrom": "release",
+    "boot": "release",
+}
+
+
+def main() -> None:
+    parser = lib.parser(__doc__)
+    parser.add_argument(
+        "artefact",
+        nargs="?",
+        default=os.environ.get("MOCHA_RELEASE_ARTEFACT") or DEFAULT_ARTEFACT,
+        help="archive to write (default: $MOCHA_RELEASE_ARTEFACT, or "
+        f"{DEFAULT_ARTEFACT})",
+    )
+    args = parser.parse_args()
+
+    for component, prefix in COMPONENTS.items():
+        lib.run(
+            "cmake",
+            "--install",
+            "build/sw",
+            "--prefix",
+            prefix,
+            "--component",
+            component,
+            dry_run=args.dry_run,
+        )
+
+    lib.run("tar", "-czvf", args.artefact, "release", dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/scripts/verilator_build.py
+++ b/ci/scripts/verilator_build.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the Verilator simulation model.
+
+Verilating and then compiling the model takes roughly a GB per job, so it gets
+a fraction of $MOCHA_JOBS (default: every core) rather than all of it.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib
+
+CORE = "lowrisc:mocha:top_chip_verilator"
+
+
+def main() -> None:
+    parser = lib.parser(__doc__)
+    parser.add_argument(
+        "--jobs-divisor",
+        type=int,
+        default=4,
+        metavar="N",
+        help="divide $MOCHA_JOBS by N (default: %(default)s; releases use 2)",
+    )
+    parser.add_argument(
+        "--traced",
+        action="store_true",
+        help="build with tracing enabled, for the nightly slow tests",
+    )
+    # Anything this parser does not recognise is passed straight to fusesoc.
+    args, fusesoc_args = parser.parse_known_args()
+
+    jobs = max(1, lib.jobs() // max(1, args.jobs_divisor))
+
+    traced = []
+    if args.traced:
+        traced = [
+            f"--verilator_options=-j {jobs} --threads 2 --trace-threads 2",
+            f"--make_options=-j {jobs}",
+        ]
+
+    if not args.dry_run:
+        print(f"Building the Verilator model with {jobs} job(s).")
+
+    lib.run(
+        "fusesoc",
+        "--cores-root=.",
+        "run",
+        "--target=sim",
+        "--tool=verilator",
+        "--setup",
+        "--build",
+        CORE,
+        *traced,
+        *fusesoc_args,
+        env={"MAKEFLAGS": f"-j{jobs}"},
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/scripts/verilator_slow_test.py
+++ b/ci/scripts/verilator_slow_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the slow Verilator tests (the nightly flow).
+
+These take hours, so the list is printed before the run: the log should say
+what it is waiting on. Needs a traced model and the software built.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib
+
+SELECT = ["--test-dir", "build/sw", "-R", "sim_verilator", "-L", "slow"]
+
+
+def main() -> None:
+    args = lib.parser(__doc__).parse_args()
+
+    lib.run("ctest", *SELECT, "--show-only", dry_run=args.dry_run)
+    lib.run("ctest", *SELECT, "--output-on-failure", dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/scripts/verilator_test.py
+++ b/ci/scripts/verilator_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the quick Verilator tests.
+
+Everything labelled 'sim_verilator' except the tests marked 'slow', which the
+nightly flow covers. Needs the model and the software built.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib
+
+
+def main() -> None:
+    args = lib.parser(__doc__).parse_args()
+
+    lib.run(
+        "ctest",
+        "--test-dir",
+        "build/sw",
+        "-R",
+        "sim_verilator",
+        "-LE",
+        "slow",
+        "--output-on-failure",
+        "-j",
+        lib.jobs(),
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780500542,
-        "narHash": "sha256-XKbtr82IfB5RXhBzWgsTnuZcS230Lq9NdFE13IM/Zi8=",
+        "lastModified": 1783444941,
+        "narHash": "sha256-x16rWWRL22gih6NTeT5eq6Gk5gK9kYXSqjuD5xPXiFM=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "c134ded39dab6c6dc15ad4675a446269c12756ff",
+        "rev": "5c92aafe5a9abf06aa69cd213a688250e255036c",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779676664,
-        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
+        "lastModified": 1782093830,
+        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
+        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781585874,
-        "narHash": "sha256-T4e8kqZ/fsuqYWbcXDcr0EBLClh3VRKVV1XcL/ibf3A=",
+        "lastModified": 1782905613,
+        "narHash": "sha256-SvXJcAemihifkTn4BGvyE5K1FJX9bl4U8DQ5pqKvD0s=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "112aebcc00ecf20d48a5c08e80660a6852a4707a",
+        "rev": "7af23cfe91064865ecf2e835da28b45b3c6f49fd",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781596548,
-        "narHash": "sha256-dhc1zBhYJbafsflK31g5+P+iot/saZPa/nUpcRkZui0=",
+        "lastModified": 1783307743,
+        "narHash": "sha256-oseisp2tblvzYZdojkA5URLnMjrpPiemzr5T7BdUyuU=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "ec7b3fd86a8add8c546192ad5d66dade40d21e48",
+        "rev": "288b0a580ede39d3d7f96e3d835f9df0a7080223",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,11 +77,19 @@
       formatter = pkgs.alejandra;
       devShells = rec {
         default = baremetal;
-        baremetal = pkgs.mkShell {
+        # CHERI baremetal + EDA development shell, built on lowrisc-nix's generic
+        # mkEdaShell. Commercial EDA tools (Xcelium, Jasper, Vivado) are declared
+        # via tool_data.json and resolved at runtime from the JSON file named by
+        # $LOWRISC_EDA_CONFIG; without that config the shell still works and just
+        # warns. Open-source tools listed in tool_data.json (Verilator, FuseSoC)
+        # are absent from that config and are simply skipped — they are still
+        # provided as Nix packages below. Enter with `nix develop`; it execs a
+        # hermetic FHS sandbox, so it is not direnv-loadable.
+        baremetal = lowrisc-nix.lib.mkEdaShell {
+          inherit pkgs;
           name = "baremetal";
-          strictDeps = true;
-          hardeningDisable = ["all"];
-          nativeBuildInputs =
+          tools = builtins.fromJSON (builtins.readFile ./tool_data.json);
+          extraDeps =
             (with pkgs; [
               bc
               bison
@@ -118,22 +126,22 @@
               verilator_5_040
               llvm_cheri
             ]);
-          buildInputs = with pkgs; [libelf zlib];
-          env = {
-            # Prevent uv from managing Python downloads
-            UV_PYTHON_DOWNLOADS = "never";
-            # Force uv to use nixpkgs Python interpreter
-            UV_PYTHON = pythonSet.python.interpreter;
+          # Project env, appended after the EDA setup (mkEdaShell has no `env`
+          # attr — buildFHSEnv takes a bash profile fragment instead).
+          profile = ''
+            # Prevent uv from managing Python downloads; force the nixpkgs interpreter.
+            export UV_PYTHON_DOWNLOADS=never
+            export UV_PYTHON=${pythonSet.python.interpreter}
 
-            SYSROOT_PURECAP = "${cheri-toolchain.linux-headers-purecap}/usr/include";
-            COMPILER_RT_PURECAP = "${cheri-toolchain.compiler-rt-builtins-purecap}/lib";
-            LIBC_PURECAP_INCLUDE = "${cheri-toolchain.muslc-linux-riscv64-purecap}/include";
-            LIBC_PURECAP_LIB = "${cheri-toolchain.muslc-linux-riscv64-purecap}/lib";
+            export SYSROOT_PURECAP=${cheri-toolchain.linux-headers-purecap}/usr/include
+            export COMPILER_RT_PURECAP=${cheri-toolchain.compiler-rt-builtins-purecap}/lib
+            export LIBC_PURECAP_INCLUDE=${cheri-toolchain.muslc-linux-riscv64-purecap}/include
+            export LIBC_PURECAP_LIB=${cheri-toolchain.muslc-linux-riscv64-purecap}/lib
 
-            HOSTCC = "${pkgs.llvmPackages_21.clang}/bin/clang";
-            HOSTCXX = "${pkgs.llvmPackages_21.clang}/bin/clang++";
-            HOSTLD = "${pkgs.llvmPackages_21.lld}/bin/ld.lld";
-          };
+            export HOSTCC=${pkgs.llvmPackages_21.clang}/bin/clang
+            export HOSTCXX=${pkgs.llvmPackages_21.clang}/bin/clang++
+            export HOSTLD=${pkgs.llvmPackages_21.lld}/bin/ld.lld
+          '';
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,13 @@
             export LIBC_PURECAP_INCLUDE=${cheri-toolchain.muslc-linux-riscv64-purecap}/include
             export LIBC_PURECAP_LIB=${cheri-toolchain.muslc-linux-riscv64-purecap}/lib
 
+            # The debugger the debug tests drive. Commercial EDA trees ship
+            # their own gdb and mkEdaShell puts their paths first, so a bare
+            # `gdb` in this shell can be a vendor build that cannot even load
+            # (Xcelium's wants libmpfr.so.4). Name ours instead of relying on
+            # $PATH order; util/gdb_response.exp reads this.
+            export GDB=${pkgs.gdb}/bin/gdb
+
             export HOSTCC=${pkgs.llvmPackages_21.clang}/bin/clang
             export HOSTCXX=${pkgs.llvmPackages_21.clang}/bin/clang++
             export HOSTLD=${pkgs.llvmPackages_21.lld}/bin/ld.lld

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
       };
       ftditool-cli = inputs.ftditool.packages.${system}.default;
       cheri-toolchain = pkgs.callPackage ./nix/cheri_toolchain.nix {inherit (lrPkgs) llvm_cheri;};
-    in {
+    in rec {
       formatter = pkgs.alejandra;
       devShells = rec {
         default = baremetal;
@@ -146,6 +146,27 @@
       };
 
       apps = {
+        # Non-interactive entry point into the baremetal shell, for running a
+        # one-off command in it: `nix run .#baremetal -- <cmd> <args>`.
+        # mkEdaShell's shellHook execs the FHS sandbox with no argv, so
+        # `nix develop -c CMD` never reaches CMD: the dispatcher sees no
+        # arguments and drops into an interactive $SHELL instead. The app
+        # payload forwards argv through to `exec "$@"` inside the sandbox.
+        baremetal = devShells.baremetal.app;
+        # CI job runner, and what the workflows call. `nix run .#ci -- <job>`
+        # runs ci/run.py inside the same baremetal shell, so a CI job and a
+        # local run of it are the same command in the same environment:
+        #   nix run .#ci -- verilator-test
+        # The workflows invoke this from an ordinary `run:` step rather than
+        # through `defaults.run.shell`, which keeps the Actions runner's own
+        # child a plain bash it can track.
+        ci = {
+          type = "app";
+          program = "${pkgs.writeShellScript "mocha-ci" ''
+            repo="$(${pkgs.git}/bin/git rev-parse --show-toplevel 2>/dev/null || pwd)"
+            exec ${devShells.baremetal.app.program} "$repo/ci/run.py" "$@"
+          ''}";
+        };
         bitstream-build = flake-utils.lib.mkApp {
           drv = fpga.bitstream-build;
         };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,8 @@ extend-exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "SIM", "PTH", "C4", "A", "RUF", "PERF"]
+
+[tool.ruff.lint.isort]
+# Standard library from 3.11, and the devshell's Python is newer than the 3.10
+# the target version keeps the rest of the tree compatible with.
+extra-standard-library = ["tomllib"]

--- a/sw/cmake/busybox.cmake
+++ b/sw/cmake/busybox.cmake
@@ -41,6 +41,7 @@ function(mocha_busybox OUTPUT_NAME)
       "CC=clang ${FLAGS}"
       HOSTCC=gcc
       "LD=ld.lld"
+      STRIP=llvm-strip
       "CFLAGS_busybox=--unwindlib=none ${FLAGS} -fuse-ld=lld"
   )
 

--- a/sw/cmake/uboot.cmake
+++ b/sw/cmake/uboot.cmake
@@ -17,9 +17,9 @@ function(mocha_uboot UBOOT_NAME)
   # build command.
   set(BUILD_COMMAND
       make
-      # override CC and LD, as U-boot defaults to using the GNU toolchain.
       "CC=clang -target riscv64-unknown-elf"
       "LD=ld.lld"
+      OBJCOPY=llvm-objcopy
   )
   
   # install command - copy the built U-Boot binary to the root of the external project directory.

--- a/tool_data.json
+++ b/tool_data.json
@@ -22,7 +22,7 @@
     {
         "name": "Vivado",
         "vendor": "Xilinx",
-        "version": "v2021.1",
+        "version": "2021.1",
         "comment": "Used to build bitstreams for Genesys 2."
     },
     {

--- a/util/gdb_response.exp
+++ b/util/gdb_response.exp
@@ -16,15 +16,32 @@ expect_before {
     eof { send_error "Error: GDB unexpectedly terminated\n"; exit 1 }
 }
 expect "build/sw/device/examples/infinite_loop"
+expect "(gdb) "
+send "set style enabled off\r"
 # Connect to OpenOCD.
 expect "(gdb) "
 send "target extended-remote localhost:3333\r"
-# Inspect a register.
+# Reset and run to a breakpoint in main instead, so every check below sees the
+# same state on every run.
+expect "(gdb) "
+send "monitor reset halt\r"
+expect "(gdb) "
+send "break *0x100000d0\r"
+expect "Breakpoint 1"
+# Booting through the ROM takes a while under Verilator, so allow more time for
+# this step than for the individual commands around it.
+expect "(gdb) "
+set timeout 300
+send "continue\r"
+expect "Breakpoint 1, main"
+set timeout 20
+# Write to a register and read it back.
+expect "(gdb) "
+send "set \$t6 = 0xdeadbeef\r"
 expect "(gdb) "
 send "info reg t6\r"
 expect "t6"
-expect "0x0"
-expect "0"
+expect "0xdeadbeef"
 # Inspect memory.
 expect "(gdb) "
 send "x/x 0x00080000\r"
@@ -39,13 +56,4 @@ send "x/x 0x80001000\r"
 expect "0xdeadbeef"
 expect "(gdb) "
 send "set *0x80001000 = 0x00000000\r"
-# Breakpoints.
 expect "(gdb) "
-send "break *0x100000d0\r"
-expect "Breakpoint 1"
-expect "(gdb) "
-send "run\r"
-expect "Start it from the beginning? (y or n) "
-send "y\r"
-expect "Starting program"
-expect "Breakpoint 1"

--- a/util/gdb_response.exp
+++ b/util/gdb_response.exp
@@ -5,7 +5,12 @@
 #
 # On timeout just wait indefinitely.
 set timeout 20
-spawn gdb build/sw/device/examples/infinite_loop
+if {[info exists env(GDB)]} {
+    set gdb $env(GDB)
+} else {
+    set gdb "gdb"
+}
+spawn $gdb build/sw/device/examples/infinite_loop
 expect_before {
     timeout { send_error "Error: GDB didn't print the expected response within the timeout\n"; exit 2 }
     eof { send_error "Error: GDB unexpectedly terminated\n"; exit 1 }


### PR DESCRIPTION
Experimental new EDA devshell.

- [x] Migrate the default devshell over to `lowrisc-nix.lib.mkEdaShell` to add support for commercial EDA tools versions are pulled from `tool_data.json`
- [x]  Removed unnecessary `v` prefix from `Vivado` version
- [x] Removed the `.envrc` (direnv) config which does `use flake` - unfortunately the new EdaShell uses FHS bubblewrap to support the EDA tools on NixOS, it is not source-able. Which means it doesn't work with direnv. This will mean we will have to manually `nix develop .`

**update:** depends on https://github.com/lowRISC/mocha/pull/702