### PR TITLE
[rtl,tagstore] Fix excessive BRAM FPGA utilisation

### DIFF
--- a/hw/vendor/patches/tagctrl/0003_BRAM_Utilisation_Fix.patch
+++ b/hw/vendor/patches/tagctrl/0003_BRAM_Utilisation_Fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/axi_llc_tag_store.sv b/src/axi_llc_tag_store.sv
+index be4d016..7ba57bc 100644
+--- a/src/axi_llc_tag_store.sv
++++ b/src/axi_llc_tag_store.sv
+@@ -270,7 +270,7 @@ module axi_llc_tag_store #(
+     prim_ram_1p #(
+       .Width           (TagDataLen),
+       .Depth           (Cfg.NumLines),
+-      .DataBitsPerMask (32'd1)
++      .DataBitsPerMask (TagDataLen)
+     ) i_tag_store (
+       .clk_i,
+       .rst_ni,

--- a/hw/vendor/tagctrl/src/axi_llc_tag_store.sv
+++ b/hw/vendor/tagctrl/src/axi_llc_tag_store.sv
@@ -270,7 +270,7 @@ module axi_llc_tag_store #(
     prim_ram_1p #(
       .Width           (TagDataLen),
       .Depth           (Cfg.NumLines),
-      .DataBitsPerMask (32'd1)
+      .DataBitsPerMask (TagDataLen)
     ) i_tag_store (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
The tag controller tag store instantiated prim_ram_1p with parameter .DataBitsPerMask(32'd1)

This allowed write strobes with one bit of granularity, but Xilinx primitives only allow write strobes with byte granularity.

Consequently Vivado was inferring a separate BRAM for each bit of width i.e. 54 BRAMs per instance instead of 1.
There are 8 instances so this PR reduces BRAM18 utilisation by ~200 (from ~300 to ~100)

Also seems to slightly reduce bitstream build time due to reduced contention, on my machine from 39 mins to 30 mins