### PR TITLE
nix: add vmanager for imc

### DIFF
--- a/tool_data.json
+++ b/tool_data.json
@@ -30,5 +30,11 @@
         "vendor": "Cadence",
         "version": "24.03-s007",
         "comment": "Provides xrun for simulations and is used to run our full UVM verification environment."
+    },
+    {
+        "name": "vManager",
+        "vendor": "Cadence",
+        "version": "24.03-s002",
+        "comment": "Provides imc for coverage."
     }
 ]


### PR DESCRIPTION
Regressions are now running with the new EDA devshell. But imc is missing which kills the coverage.