### PR TITLE
[sram] SRAM updates for D1 Signoff

### DIFF
--- a/hw/top_chip/axi_sram.core
+++ b/hw/top_chip/axi_sram.core
@@ -1,0 +1,55 @@
+CAPI=2:
+# Copyright lowRISC contributors (COSMIC project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:mocha:axi_sram"
+description: "AXI SRAM with CHERI tag storage"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:mocha_constants:top_pkg
+      - pulp-platform.org::axi
+      - lowrisc:prim:assert:0.1
+      - lowrisc:prim:ram_1p
+    files:
+      - rtl/axi_sram.sv
+    file_type: systemVerilogSource
+
+  # Standalone builds have nothing else to pick a provider for the virtual
+  # prim:ram_1p core, and would otherwise get the Xilinx one. The top selects a
+  # provider for itself, so this must not be part of the default target.
+  files_ram_1p_generic:
+    depend:
+      - lowrisc:prim_generic:ram_1p
+
+  files_verilator_waiver:
+    files:
+      - lint/top_chip_system.vlt
+    file_type: vlt
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator ? (files_verilator_waiver)
+      - files_rtl
+    toplevel: axi_sram
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    filesets_append:
+      - files_ram_1p_generic
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine

--- a/hw/top_chip/rtl/axi_sram.sv
+++ b/hw/top_chip/rtl/axi_sram.sv
@@ -158,4 +158,15 @@ module axi_sram #(
     end
   end
 
+  // The read data and tag are deliberately omitted, since access to uninitialized memory reads X
+  `ASSERT_KNOWN(AwReadyKnownO_A, axi_resp_o.aw_ready)
+  `ASSERT_KNOWN(ArReadyKnownO_A, axi_resp_o.ar_ready)
+  `ASSERT_KNOWN(WReadyKnownO_A, axi_resp_o.w_ready)
+  `ASSERT_KNOWN(BValidKnownO_A, axi_resp_o.b_valid)
+  `ASSERT_KNOWN(RValidKnownO_A, axi_resp_o.r_valid)
+  `ASSERT_KNOWN_IF(BKnownO_A, axi_resp_o.b, axi_resp_o.b_valid)
+  `ASSERT_KNOWN_IF(RIdKnownO_A, axi_resp_o.r.id, axi_resp_o.r_valid)
+  `ASSERT_KNOWN_IF(RRespKnownO_A, axi_resp_o.r.resp, axi_resp_o.r_valid)
+  `ASSERT_KNOWN_IF(RLastKnownO_A, axi_resp_o.r.last, axi_resp_o.r_valid)
+
 endmodule

--- a/hw/top_chip/rtl/axi_sram.sv
+++ b/hw/top_chip/rtl/axi_sram.sv
@@ -18,9 +18,10 @@ module axi_sram #(
 );
 
   // Every tag entry can store AxiDataWidth capability tags
-  localparam int unsigned TagBitAddrWidth = AddrWidth - $clog2(top_pkg::CapSizeBits / 8);
+  localparam int unsigned TagBitAddrWidth = AddrWidth -
+                                            $clog2(top_pkg::CapSizeBits / top_pkg::AxiDataWidth);
   localparam int unsigned TagAddrWidth    = TagBitAddrWidth - $clog2(top_pkg::AxiDataWidth);
-  localparam int unsigned TagBitWith      = $clog2(top_pkg::AxiDataWidth);
+  localparam int unsigned TagBitWidth     = $clog2(top_pkg::AxiDataWidth);
 
   // 64-bit memory format signals
   logic                                 sram_req;
@@ -34,7 +35,7 @@ module axi_sram #(
   logic [    top_pkg::AxiDataWidth-1:0] sram_wmask;
   logic [          TagBitAddrWidth-1:0] sram_tag_bit_addr;
   logic [             TagAddrWidth-1:0] sram_tag_word_addr;
-  logic [               TagBitWith-1:0] sram_tag_bit_select_d, sram_tag_bit_select_q;
+  logic [              TagBitWidth-1:0] sram_tag_bit_select_d, sram_tag_bit_select_q;
   logic [    top_pkg::AxiDataWidth-1:0] sram_tag_wmask;
   logic [    top_pkg::AxiDataWidth-1:0] sram_tag_wdata;
   logic [    top_pkg::AxiDataWidth-1:0] sram_tag_rdata;
@@ -157,6 +158,17 @@ module axi_sram #(
       sram_tag_bit_select_q <= sram_tag_bit_select_d;
     end
   end
+
+  // The tag memory must hold one bit for every capability-sized region of the data memory.
+  `ASSERT_INIT(TagRamCoversDataRam_A,
+               (2 ** TagAddrWidth) * top_pkg::AxiDataWidth * top_pkg::CapSizeBits ==
+               (2 ** AddrWidth) * top_pkg::AxiDataWidth)
+
+  // The data memory must be exactly the size the address map reserves for it. The addresses are
+  // masked with SRAMMask, so a parameter that disagrees with the map would silently wrap.
+  `ASSERT_INIT(SramSizeMatchesMap_A,
+               2 ** AddrWidth ==
+               (top_pkg::SRAMMask + 1) / (top_pkg::AxiDataWidth / 8))
 
   // The read data and tag are deliberately omitted, since access to uninitialized memory reads X
   `ASSERT_KNOWN(AwReadyKnownO_A, axi_resp_o.aw_ready)

--- a/hw/top_chip/top_chip_system.core
+++ b/hw/top_chip/top_chip_system.core
@@ -22,6 +22,7 @@ filesets:
       - lowrisc:mocha_ip:pwrmgr
       - lowrisc:mocha_ip:rstmgr
       - lowrisc:mocha_ip:rv_plic
+      - lowrisc:mocha:axi_sram
       - lowrisc:prim:onehot
       - lowrisc:tlul:adapter_host
       - lowrisc:tlul:adapter_reg
@@ -35,7 +36,6 @@ filesets:
       - cosmic:pulp:axi_riscv_atomics
     files:
       - rtl/mem_downsizer.sv
-      - rtl/axi_sram.sv
       - rtl/top_chip_system.sv
     file_type: systemVerilogSource
 


### PR DESCRIPTION
This PR makes a few updates to the SRAM block to prepare it for D1 signoff.

Primarily:
- It creates a standalone fuseSoC file for the SRAM
- Adds ASSERT_KNOWN assertions on outputs where needed
- fixes an RTL bug within the SRAM that causes the tag array to be 8x smaller than it should be