### PR TITLE
[i2c] add the missing output known assertion

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/i2c/rtl/i2c.sv
+++ b/hw/vendor/lowrisc_ip/ip/i2c/rtl/i2c.sv
@@ -178,6 +178,7 @@ module i2c
   `ASSERT_KNOWN(IntrHostTimeoutKnownO_A, intr_host_timeout_o)
   `ASSERT_KNOWN(LsioTriggerKnown_A, lsio_trigger_o)
   `ASSERT_KNOWN(RaclErrorValidKnown_A, racl_error_o.valid)
+  `ASSERT_KNOWN(RamCfgRspKnownO_A, ram_cfg_rsp_o)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/vendor/patches/lowrisc_ip/i2c/0002-Add-ram-cfg-rsp-known-assertion.patch
+++ b/hw/vendor/patches/lowrisc_ip/i2c/0002-Add-ram-cfg-rsp-known-assertion.patch
@@ -1,0 +1,12 @@
+diff --git a/rtl/i2c.sv b/rtl/i2c.sv
+index 4040fc35..64460fc1 100644
+--- a/rtl/i2c.sv
++++ b/rtl/i2c.sv
+@@ -178,6 +178,7 @@ module i2c
+   `ASSERT_KNOWN(IntrHostTimeoutKnownO_A, intr_host_timeout_o)
+   `ASSERT_KNOWN(LsioTriggerKnown_A, lsio_trigger_o)
+   `ASSERT_KNOWN(RaclErrorValidKnown_A, racl_error_o.valid)
++  `ASSERT_KNOWN(RamCfgRspKnownO_A, ram_cfg_rsp_o)
+ 
+   // Alert assertions for reg_we onehot check
+   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])


### PR DESCRIPTION
Add missing ASSERT_KNOWN assertion for ram_cfg_rsp_o. Closes #708.