### PR TITLE
[kmac] add missing output known assertions

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/kmac/rtl/kmac.sv
+++ b/hw/vendor/lowrisc_ip/ip/kmac/rtl/kmac.sv
@@ -1535,6 +1535,9 @@ module kmac
   `ASSERT_KNOWN(TlOAReadyKnown_A, tl_o.a_ready)
   `ASSERT_KNOWN(AlertKnownO_A, alert_tx_o)
   `ASSERT_KNOWN(EnMaskingKnown_A, en_masking_o)
+  `ASSERT_KNOWN(IdleKnownO_A, idle_o)
+  `ASSERT_KNOWN(EntropyKnownO_A, entropy_o)
+  `ASSERT_KNOWN(AppKnownO_A, app_o)
 
   // Parameter as desired
   `ASSERT_INIT(SecretKeyDivideBy32_A, (kmac_pkg::MaxKeyLen % 32) == 0)

--- a/hw/vendor/patches/lowrisc_ip/kmac/0005-Add-missing-output-known-assertions.patch
+++ b/hw/vendor/patches/lowrisc_ip/kmac/0005-Add-missing-output-known-assertions.patch
@@ -1,0 +1,14 @@
+diff --git a/rtl/kmac.sv b/rtl/kmac.sv
+index 17526815..833be99e 100644
+--- a/rtl/kmac.sv
++++ b/rtl/kmac.sv
+@@ -1535,6 +1535,9 @@ module kmac
+   `ASSERT_KNOWN(TlOAReadyKnown_A, tl_o.a_ready)
+   `ASSERT_KNOWN(AlertKnownO_A, alert_tx_o)
+   `ASSERT_KNOWN(EnMaskingKnown_A, en_masking_o)
++  `ASSERT_KNOWN(IdleKnownO_A, idle_o)
++  `ASSERT_KNOWN(EntropyKnownO_A, entropy_o)
++  `ASSERT_KNOWN(AppKnownO_A, app_o)
+ 
+   // Parameter as desired
+   `ASSERT_INIT(SecretKeyDivideBy32_A, (kmac_pkg::MaxKeyLen % 32) == 0)


### PR DESCRIPTION
app_o, entropy_o and idle_o had no ASSERT_KNOWN. idle_o is a registered mubi4 and entropy_o is driven from a synchroniser or tied off, so both are always known; app_o holds up unconditionally too.

The vendored source is patched in place and the change is recorded in 0005-Add-missing-output-known-assertions.patch.

kmac_smoke passes 3/3 with Xcelium in both the unmasked and masked configurations.

Closes #707