### PR TITLE
[gpio] add missing output known assertions

### DIFF
--- a/hw/top_chip/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_chip/ip_autogen/gpio/rtl/gpio.sv
@@ -244,6 +244,17 @@ module gpio
   `ASSERT_KNOWN(CioGpioOKnown, cio_gpio_o)
   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
   `ASSERT_KNOWN(RaclErrorValidKnown_A, racl_error_o.valid)
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
+  // d_data intentionally omitted.
+  `ASSERT_KNOWN_IF(TlDOpcodeKnownO_A, tl_o.d_opcode, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDParamKnownO_A, tl_o.d_param, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDSizeKnownO_A, tl_o.d_size, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDSourceKnownO_A, tl_o.d_source, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDSinkKnownO_A, tl_o.d_sink, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDErrorKnownO_A, tl_o.d_error, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDUserKnownO_A, tl_o.d_user, tl_o.d_valid)
+  `ASSERT_KNOWN(SampledStrapsKnownO_A, sampled_straps_o)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/vendor/lowrisc_ip/ip_templates/gpio/rtl/gpio.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/gpio/rtl/gpio.sv.tpl
@@ -420,6 +420,17 @@ module ${module_instance_name}
   `ASSERT_KNOWN(CioGpioOKnown, cio_gpio_o)
   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
   `ASSERT_KNOWN(RaclErrorValidKnown_A, racl_error_o.valid)
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
+  // d_data intentionally omitted.
+  `ASSERT_KNOWN_IF(TlDOpcodeKnownO_A, tl_o.d_opcode, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDParamKnownO_A, tl_o.d_param, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDSizeKnownO_A, tl_o.d_size, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDSourceKnownO_A, tl_o.d_source, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDSinkKnownO_A, tl_o.d_sink, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDErrorKnownO_A, tl_o.d_error, tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlDUserKnownO_A, tl_o.d_user, tl_o.d_valid)
+  `ASSERT_KNOWN(SampledStrapsKnownO_A, sampled_straps_o)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/vendor/patches/lowrisc_ip/gpio/0002_add_missing_output_assertions.patch
+++ b/hw/vendor/patches/lowrisc_ip/gpio/0002_add_missing_output_assertions.patch
@@ -1,0 +1,20 @@
+--- a/rtl/gpio.sv.tpl
++++ b/rtl/gpio.sv.tpl
+@@ -420,6 +420,17 @@
+   `ASSERT_KNOWN(CioGpioOKnown, cio_gpio_o)
+   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
+   `ASSERT_KNOWN(RaclErrorValidKnown_A, racl_error_o.valid)
++  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
++  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
++  // d_data intentionally omitted.
++  `ASSERT_KNOWN_IF(TlDOpcodeKnownO_A, tl_o.d_opcode, tl_o.d_valid)
++  `ASSERT_KNOWN_IF(TlDParamKnownO_A, tl_o.d_param, tl_o.d_valid)
++  `ASSERT_KNOWN_IF(TlDSizeKnownO_A, tl_o.d_size, tl_o.d_valid)
++  `ASSERT_KNOWN_IF(TlDSourceKnownO_A, tl_o.d_source, tl_o.d_valid)
++  `ASSERT_KNOWN_IF(TlDSinkKnownO_A, tl_o.d_sink, tl_o.d_valid)
++  `ASSERT_KNOWN_IF(TlDErrorKnownO_A, tl_o.d_error, tl_o.d_valid)
++  `ASSERT_KNOWN_IF(TlDUserKnownO_A, tl_o.d_user, tl_o.d_valid)
++  `ASSERT_KNOWN(SampledStrapsKnownO_A, sampled_straps_o)
+ 
+   // Alert assertions for reg_we onehot check
+   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])


### PR DESCRIPTION
add ASSERT_KNOWN for tl_o and sampled_straps_o. tl_o follows the convention used by the other blocks, asserting on the d_valid and a_ready handshakes.

GPIO is generated with ipgen, so the change goes in the template and in the generated RTL, and is recorded in
0002_add_missing_output_assertions.patch.

Verfied with a 3/3 pass using:
`dvsim hw/top_chip/ip_autogen/gpio/dv/gpio_sim_cfg.hjson --tool xcelium  -i gpio_smoke  --reseed 3`

Closes #711