### PR TITLE
[pwrmgr] add missing output known assertions

### DIFF
--- a/hw/top_chip/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_chip/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -709,6 +709,10 @@ module pwrmgr
   `ASSERT_KNOWN(OtpKnownO_A,       pwr_otp_o        )
   `ASSERT_KNOWN(LcKnownO_A,        pwr_lc_o         )
   `ASSERT_KNOWN(IntrKnownO_A,      intr_wakeup_o    )
+  `ASSERT_KNOWN(FetchEnKnownO_A,   fetch_en_o       )
+  `ASSERT_KNOWN(StrapKnownO_A,     strap_o          )
+  `ASSERT_KNOWN(LowPowerKnownO_A,  low_power_o      )
+  `ASSERT_KNOWN(EscRstRxKnownO_A,  esc_rst_rx_o     )
 
   // EscTimeOutCnt also sets the required clock ratios between escalator and local clock
   // Ie, clk_lc cannot be so slow that the timeout count is reached

--- a/hw/vendor/lowrisc_ip/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -789,6 +789,10 @@ module pwrmgr
   `ASSERT_KNOWN(OtpKnownO_A,       pwr_otp_o        )
   `ASSERT_KNOWN(LcKnownO_A,        pwr_lc_o         )
   `ASSERT_KNOWN(IntrKnownO_A,      intr_wakeup_o    )
+  `ASSERT_KNOWN(FetchEnKnownO_A,   fetch_en_o       )
+  `ASSERT_KNOWN(StrapKnownO_A,     strap_o          )
+  `ASSERT_KNOWN(LowPowerKnownO_A,  low_power_o      )
+  `ASSERT_KNOWN(EscRstRxKnownO_A,  esc_rst_rx_o     )
 
   // EscTimeOutCnt also sets the required clock ratios between escalator and local clock
   // Ie, clk_lc cannot be so slow that the timeout count is reached

--- a/hw/vendor/patches/lowrisc_ip/pwrmgr/0005_Add_Missing_Output_Assertions.patch
+++ b/hw/vendor/patches/lowrisc_ip/pwrmgr/0005_Add_Missing_Output_Assertions.patch
@@ -1,0 +1,15 @@
+diff --git a/rtl/pwrmgr.sv.tpl b/rtl/pwrmgr.sv.tpl
+index 429be1e1..c864a334 100644
+--- a/rtl/pwrmgr.sv.tpl
++++ b/rtl/pwrmgr.sv.tpl
+@@ -789,6 +789,10 @@ module pwrmgr
+   `ASSERT_KNOWN(OtpKnownO_A,       pwr_otp_o        )
+   `ASSERT_KNOWN(LcKnownO_A,        pwr_lc_o         )
+   `ASSERT_KNOWN(IntrKnownO_A,      intr_wakeup_o    )
++  `ASSERT_KNOWN(FetchEnKnownO_A,   fetch_en_o       )
++  `ASSERT_KNOWN(StrapKnownO_A,     strap_o          )
++  `ASSERT_KNOWN(LowPowerKnownO_A,  low_power_o      )
++  `ASSERT_KNOWN(EscRstRxKnownO_A,  esc_rst_rx_o     )
+ 
+   // EscTimeOutCnt also sets the required clock ratios between escalator and local clock
+   // Ie, clk_lc cannot be so slow that the timeout count is reached


### PR DESCRIPTION
add ASSERT_KNOWN to fetch_en_o, strap_o, low_power_o and esc_rst_rx_o.

The power manager is generated with ipgen, so the change goes in the template and in the generated RTL, and is recorded in 0005_Add_Missing_Output_Assertions.patch.

`dvsim hw/top_chip/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson --tool xcelium -i pwrmgr_smoke --reseed 3` passes with 3/3.