### PR TITLE
[rstmgr] add missing output known assertion

### DIFF
--- a/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_chip/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -701,6 +701,7 @@ module rstmgr
   `ASSERT_KNOWN(PwrKnownO_A,         pwr_o         )
   `ASSERT_KNOWN(ResetsKnownO_A,      resets_o      )
   `ASSERT_KNOWN(RstEnKnownO_A,       rst_en_o      )
+  `ASSERT_KNOWN(SwRstReqKnownO_A,    sw_rst_req_o  )
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/vendor/lowrisc_ip/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
+++ b/hw/vendor/lowrisc_ip/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
@@ -476,6 +476,7 @@ module rstmgr
   `ASSERT_KNOWN(PwrKnownO_A,         pwr_o         )
   `ASSERT_KNOWN(ResetsKnownO_A,      resets_o      )
   `ASSERT_KNOWN(RstEnKnownO_A,       rst_en_o      )
+  `ASSERT_KNOWN(SwRstReqKnownO_A,    sw_rst_req_o  )
 % for intf in export_rsts:
   `ASSERT_KNOWN(${intf.capitalize()}ResetsKnownO_A, resets_${intf}_o )
 % endfor

--- a/hw/vendor/patches/lowrisc_ip/rstmgr/0004_Add_Missing_Output_Assertions.patch
+++ b/hw/vendor/patches/lowrisc_ip/rstmgr/0004_Add_Missing_Output_Assertions.patch
@@ -1,0 +1,12 @@
+diff --git a/rtl/rstmgr.sv.tpl b/rtl/rstmgr.sv.tpl
+index ead332ab..3768a457 100644
+--- a/rtl/rstmgr.sv.tpl
++++ b/rtl/rstmgr.sv.tpl
+@@ -476,6 +476,7 @@ module rstmgr
+   `ASSERT_KNOWN(PwrKnownO_A,         pwr_o         )
+   `ASSERT_KNOWN(ResetsKnownO_A,      resets_o      )
+   `ASSERT_KNOWN(RstEnKnownO_A,       rst_en_o      )
++  `ASSERT_KNOWN(SwRstReqKnownO_A,    sw_rst_req_o  )
+ % for intf in export_rsts:
+   `ASSERT_KNOWN(${intf.capitalize()}ResetsKnownO_A, resets_${intf}_o )
+ % endfor


### PR DESCRIPTION
Add ASSERT_KNOWN to sw_rst_req_o.

The reset manager is generated with ipgen, so the change goes in the template and in the generated RTL, and is recorded in 0004_Add_Missing_Output_Assertions.patch.

`dvsim hw/top_chip/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson --tool xcelium -i rstmgr_smoke --reseed 3` passes with 3/3.